### PR TITLE
file extension parameter for ggsave() to allow device specification for files without extension

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,11 @@ ggplot2 1.0.1.9000
 * `theme_minimal()` got slightly more minimal by removing the axis ticks:
   labels now line up beneath the grid lines (@tomschloss, #1084)
 
+* Parameter `device` now supports character argument to specify which supported
+  device to use ('pdf', 'png', 'jpeg', etc.), for when it cannot be correctly
+  inferred from the file extension (for example when a temporay filename is
+  supplied server side in shiny apps) (@sebkopf, #939)
+
 * `ggsave()` has been simplified a little to make it easier to maintain.
   It no longer checks that you're printing a ggplot2 object (so now also
   works with any grid grob) (#970), and always requires a filename.

--- a/R/save.r
+++ b/R/save.r
@@ -7,7 +7,8 @@
 #'
 #' @param filename File name to create on disk.
 #' @param plot Plot to save, defaults to last plot displayed.
-#' @param device Device to use. By default, extracted from extension.
+#' @param device Device to use (function or any of the recognized extensions,
+#'   e.g. \code{"pdf"}). By default, extracted from filename extension.
 #'   \code{ggsave} currently recognises eps/ps, tex (pictex), pdf, jpeg, tiff,
 #'   png, bmp, svg and wmf (windows only).
 #' @param path Path to save plot to (combined with filename).
@@ -34,6 +35,12 @@
 #'
 #' unlink("ratings.pdf")
 #' unlink("ratings.png")
+#'
+#' # specify device when saving to a file with unknown extension
+#' # (for example a server supplied temporary file)
+#' file <- tempfile()
+#' ggsave(file, device = "pdf")
+#' unlink(file)
 #' }
 ggsave <- function(filename, plot = last_plot(),
                    device = default_device(filename), path = NULL, scale = 1,
@@ -65,7 +72,20 @@ ggsave <- function(filename, plot = last_plot(),
   default_device <- function(filename) {
     pieces <- strsplit(filename, "\\.")[[1]]
     ext <- tolower(pieces[length(pieces)])
+    match_device(ext)
+  }
+
+  match_device <- function(ext) {
+    if(!exists(ext, mode = "function")) {
+      stop("No graphics device defined for the file extension '", ext, "'. ",
+           "Make sure to specify a filename with supported extension or ",
+           "set the device parameter.", call. = FALSE)
+    }
     match.fun(ext)
+  }
+
+  if (is.character(device)) {
+    device <- match_device(device)
   }
 
   dim <- plot_dim(c(width, height), scale = scale, units = units,

--- a/man/ggsave.Rd
+++ b/man/ggsave.Rd
@@ -13,7 +13,8 @@ ggsave(filename, plot = last_plot(), device = default_device(filename),
 
 \item{plot}{Plot to save, defaults to last plot displayed.}
 
-\item{device}{Device to use. By default, extracted from extension.
+\item{device}{Device to use (function or any of the recognized extensions,
+e.g. \code{"pdf"}). By default, extracted from filename extension.
 \code{ggsave} currently recognises eps/ps, tex (pictex), pdf, jpeg, tiff,
 png, bmp, svg and wmf (windows only).}
 
@@ -53,6 +54,12 @@ ggsave("ratings.pdf", width = 20, height = 20, units = "cm")
 
 unlink("ratings.pdf")
 unlink("ratings.png")
+
+# specify device when saving to a file with unknown extension
+# (for example a server supplied temporary file)
+file <- tempfile()
+ggsave(file, device = "pdf")
+unlink(file)
 }
 }
 


### PR DESCRIPTION
Thank you for the fantastic ggplots package!
  
This is a suggested implementation for specifying a file extension in ```ggsave``` to allow device matching (pdf, png, jpg, etc.) for filenames without extension. The suggestion is motivated by the problem of using ggsave in a shinyApp for letting the user download a plot (for example addressed on StackOverflow here: http://stackoverflow.com/questions/14810409/save-plots-made-in-a-shiny-app). Because the shiny server provides a temporary file without extension, ggsave can't match to any of the internally defined device functions. I'm not aware of a currently available solution to this problem and although there are several work-arounds, I like the simplicity of ggsave and wanted to suggest this solution (not sure if it's the best way to do it, but it's the most elegant I could think of). This would allow use of ```ggsave``` for a shinyApp ```downloadHandler``` like so:
  
  ```coffee
# In ui.R:
downloadLink('downloadPlot', 'Download')

# In server.R:
output$downloadPlot <- downloadHandler(
  filename = "myplot.pdf",
  content = function(file) {
    ggsave(file, plot = qplot(speed, dist, data = cars), ext = "pdf")
  }
)
```
I'm relatively new to GitHub and this is my second contribution to someone else's project, please forgive if I'm missing some specific conventions or etiquette about forking/pull requests.

Sebastian
