### PR TITLE
Fix for bad URL in qplot docs

### DIFF
--- a/R/quick-plot.r
+++ b/R/quick-plot.r
@@ -4,7 +4,7 @@
 #' designed to be familiar if you're used to \code{\link{plot}}
 #' from the base package. It is a convenient wrapper for creating
 #' a number of different types of plots using a consistent
-#' calling scheme. See \url{http://had.co.nz/ggplot2/book/qplot.pdf}
+#' calling scheme. See \url{http://ggplot2.org/book/qplot.pdf}
 #' for the chapter in the \code{ggplot2} book which describes the usage
 #' of \code{qplot} in detail.
 #'

--- a/man/qplot.Rd
+++ b/man/qplot.Rd
@@ -51,7 +51,7 @@ or two-sided}
 designed to be familiar if you're used to \code{\link{plot}}
 from the base package. It is a convenient wrapper for creating
 a number of different types of plots using a consistent
-calling scheme. See \url{http://had.co.nz/ggplot2/book/qplot.pdf}
+calling scheme. See \url{http://ggplot2.org/book/qplot.pdf}
 for the chapter in the \code{ggplot2} book which describes the usage
 of \code{qplot} in detail.
 }


### PR DESCRIPTION
The URL for the sample chapter on the qplot function in both the R docs and the man docs were pointing to an old, no longer available URL. I've updated the documentation to point to the latest URL.
