### PR TITLE
Facet titles

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -38,6 +38,13 @@ ggplot2 1.0.1.9000
 
 * `Geom`, `Stat` and `Position` are now exported, making it easier to create
   new geoms, stats and positions in other packages (#989).
+* `facet_grid()` and `facet_wrap()` gain a `switch` argument that
+  allows the facet titles to be displayed near the axes. They then act
+  as axes subtitles. Can be set to "x", "y" or "both" (the latter only
+  for grids) to control which label strips are switched. (@lionel-)
+
+* `Geom` is now exported, making it easier to create new geoms in other
+  packages (#989).
 
 * New `theme_void()`, which is completely empty. Useful for plots with non
   standard coordinates or for producing numerical drawings with R. (@jiho, #976)

--- a/R/facet-labels.r
+++ b/R/facet-labels.r
@@ -182,7 +182,7 @@ labeller <- function(..., keep.as.numeric=FALSE) {
 
 
 # Grob for strip labels
-ggstrip <- function(text, horizontal=TRUE, theme) {
+ggstrip <- function(text, horizontal = TRUE, theme) {
   text_theme <- if (horizontal) "strip.text.x" else "strip.text.y"
   if (is.list(text)) text <- text[[1]]
 
@@ -196,4 +196,16 @@ ggstrip <- function(text, horizontal=TRUE, theme) {
     width = grobWidth(label) + unit(0.5, "lines"),
     height = grobHeight(label) + unit(0.5, "lines")
   ))
+}
+
+
+# Helper to adjust angle of switched strips
+adjust_angle <- function(angle) {
+  if (is.null(angle)) {
+    -90
+  } else if ((angle + 180) > 360) {
+    angle - 180
+  } else {
+    angle + 180
+  }
 }

--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -107,6 +107,8 @@ theme_grey <- function(base_size = 12, base_family = "") {
     strip.background =   element_rect(fill = "grey80", colour = NA),
     strip.text.x =       element_text(),
     strip.text.y =       element_text(angle = -90),
+    strip.switch.pad.grid = unit(0.9, "cm"),
+    strip.switch.pad.wrap = unit(0.3, "cm"),
 
     plot.background =    element_rect(colour = "white"),
     plot.title =         element_text(size = rel(1.2)),

--- a/R/theme-elements.r
+++ b/R/theme-elements.r
@@ -277,6 +277,8 @@ el_def <- function(class = NULL, inherit = NULL, description = NULL) {
   strip.background    = el_def("element_rect", "rect"),
   strip.text.x        = el_def("element_text", "strip.text"),
   strip.text.y        = el_def("element_text", "strip.text"),
+  strip.switch.pad.grid = el_def("unit"),
+  strip.switch.pad.wrap = el_def("unit"),
 
   plot.background     = el_def("element_rect", "rect"),
   plot.title          = el_def("element_text", "title"),

--- a/R/theme.r
+++ b/R/theme.r
@@ -177,6 +177,10 @@ print.theme <- function(x, ...) str(x)
 #'                    (\code{element_text}; inherits from \code{strip.text}) \cr
 #'   strip.text.y     \tab facet labels along vertical direction
 #'                    (\code{element_text}; inherits from \code{strip.text}) \cr
+#'   strip.switch.pad.grid \tab space between strips and axes when strips are switched
+#'                    (\code{unit}) \cr
+#'   strip.switch.pad.wrap \tab space between strips and axes when strips are switched
+#'                    (\code{unit}) \cr
 #' }
 #'
 #' @param ... a list of element name, element pairings that modify the

--- a/man/facet_grid.Rd
+++ b/man/facet_grid.Rd
@@ -5,7 +5,8 @@
 \title{Lay out panels in a grid.}
 \usage{
 facet_grid(facets, margins = FALSE, scales = "fixed", space = "fixed",
-  shrink = TRUE, labeller = "label_value", as.table = TRUE, drop = TRUE)
+  shrink = TRUE, labeller = "label_value", as.table = TRUE,
+  switch = NULL, drop = TRUE)
 }
 \arguments{
 \item{facets}{a formula with the rows (of the tabular display) on the LHS
@@ -44,6 +45,12 @@ to other options.}
 \item{as.table}{If \code{TRUE}, the default, the facets are laid out like
 a table with highest values at the bottom-right. If \code{FALSE}, the
 facets are laid out like a plot with the highest value at the top-right.}
+
+\item{switch}{By default, the labels are displayed on the top and
+right of the plot. If \code{"x"}, the top labels will be
+displayed to the bottom. If \code{"y"}, the right-hand side
+labels will be displayed to the left. Can also be set to
+\code{"both"}.}
 
 \item{drop}{If \code{TRUE}, the default, all factor levels not used in the
 data will automatically be dropped. If \code{FALSE}, all factor levels
@@ -180,6 +187,20 @@ mg + facet_grid(vs + am ~ gear, margins = "am")
 mg + facet_grid(vs + am ~ gear, margins = "vs")
 mg + facet_grid(vs + am ~ gear, margins = "gear")
 mg + facet_grid(vs + am ~ gear, margins = c("gear", "am"))
+
+# The facet strips can be displayed near the axes with switch
+data <- transform(mtcars,
+  am = factor(am, levels = 0:1, c("Automatic", "Manual")),
+  gear = factor(gear, levels = 3:5, labels = c("Three", "Four", "Five"))
+)
+p <- ggplot(data, aes(mpg, disp)) + geom_point()
+p + facet_grid(am ~ gear, switch = "both") + theme_light()
+
+# It may be more aesthetic to use a theme without boxes around
+# around the strips.
+p + facet_grid(am ~ gear + vs, switch = "y") + theme_minimal()
+p + facet_grid(am ~ ., switch = "y") +
+  theme_gray() \%+replace\% theme(strip.background  = element_blank())
 }
 }
 

--- a/man/facet_wrap.Rd
+++ b/man/facet_wrap.Rd
@@ -5,7 +5,7 @@
 \title{Wrap a 1d ribbon of panels into 2d.}
 \usage{
 facet_wrap(facets, nrow = NULL, ncol = NULL, scales = "fixed",
-  shrink = TRUE, as.table = TRUE, drop = TRUE)
+  shrink = TRUE, as.table = TRUE, switch = NULL, drop = TRUE)
 }
 \arguments{
 \item{facets}{Either a formula or character vector. Use either a
@@ -24,6 +24,11 @@ before statistical summary.}
 \item{as.table}{If \code{TRUE}, the default, the facets are laid out like
 a table with highest values at the bottom-right. If \code{FALSE}, the
 facets are laid out like a plot with the highest value at the top-right.}
+
+\item{switch}{By default, the labels are displayed on the top of
+the plot. If \code{switch} is \code{"x"}, they will be displayed
+to the bottom. If \code{"y"}, they will be displayed to the
+left, near the y axis.}
 
 \item{drop}{If \code{TRUE}, the default, all factor levels not used in the
 data will automatically be dropped. If \code{FALSE}, all factor levels
@@ -75,5 +80,36 @@ ggplot(mpg, aes(displ, hwy)) +
   geom_point(data = transform(mpg, class = NULL), colour = "grey85") +
   geom_point() +
   facet_wrap(~class)
+
+\dontrun{
+# Use `switch` to display the facet labels near an axis, acting as
+# a subtitle for this axis. This is typically used with free scales
+# and a theme without boxes around strip labels.
+library("dplyr")
+library("tidyr")
+data <- mtcars \%>\%
+  mutate(Logarithmic = log(mpg),
+         Inverse = 1/mpg,
+         Quadratic = mpg^2,
+         Original = mpg) \%>\%
+  gather(mpg_trans, mpg2, Logarithmic:Original)
+p <- ggplot(data, aes(mpg, disp)) + geom_point()
+
+p + aes(x = mpg2) +
+  facet_wrap(~ mpg_trans, ncol = 2, scales = "free", switch = "x") +
+  theme() \%+replace\% theme(strip.background = element_blank())
+
+
+data <- data \%>\%
+  mutate(Logarithmic = log(disp),
+         Inverse = 1/disp,
+         Quadratic = disp^2,
+         Original = disp) \%>\%
+  gather(dpg_trans, disp2, Logarithmic:Original)
+
+p \%+\% data + aes(y = disp2) +
+  facet_wrap(~ dpg_trans, ncol = 2, scales = "free", switch = "y") +
+  theme_minimal()
+}
 }
 

--- a/man/scale_hue.Rd
+++ b/man/scale_hue.Rd
@@ -33,8 +33,7 @@ to control name, limits, breaks, labels and so forth.}
 
 \item{h}{range of hues to use, in [0, 360]}
 
-\item{c}{chroma (intensity of colour), maximum value varies depending on
-combination of hue and luminance.}
+\item{c}{chroma (intensity of colour), maximum value varies depending on}
 
 \item{l}{luminance (lightness), in [0, 100]}
 

--- a/man/theme.Rd
+++ b/man/theme.Rd
@@ -152,6 +152,10 @@ The individual theme elements are:
                    (\code{element_text}; inherits from \code{strip.text}) \cr
   strip.text.y     \tab facet labels along vertical direction
                    (\code{element_text}; inherits from \code{strip.text}) \cr
+  strip.switch.pad.grid \tab space between strips and axes when strips are switched
+                   (\code{unit}) \cr
+  strip.switch.pad.wrap \tab space between strips and axes when strips are switched
+                   (\code{unit}) \cr
 }
 }
 \examples{


### PR DESCRIPTION
This implements a `switch_strips` argument to `facet_wrap` and `facet_grid`, which can be set to `x`, `y` or `both` (the latter only for grids). This allows to display the facet strips near the axes. They then act as axes subtitles. The padding between the switched strips and their corresponding axes can be adjusted through a new theme setting.

Displaying the facet titles near the axes especially makes sense when the facet title directly characterize a change in the axis (for example, a transformation, a different measure, etc). This should be typically used in conjunction with a theme without boxes around the strips. I go over this in the updated documentation.

A grid facetting with strips switched to both axes:
![facet1](https://cloud.githubusercontent.com/assets/4465050/3280482/1c1e20c4-f466-11e3-8718-a9dcbd88b551.png)

A wrap facetting with free scales and strips switched to the x axis:
![facet2](https://cloud.githubusercontent.com/assets/4465050/3280481/1c1dcd0e-f466-11e3-9ae3-403ca7b3d9a3.png)
