### PR TITLE
Edit warning message to reflect intuitive use

### DIFF
--- a/R/position-stack.r
+++ b/R/position-stack.r
@@ -48,7 +48,7 @@ PositionStack <- proto(Position, {
     }
 
     if (!is.null(data$ymin) && !all(data$ymin == 0))
-      warning("Stacking not well defined when ymin != 0", call. = FALSE)
+      warning("Stacking not well defined when ymin < 0", call. = FALSE)
 
     collide(data, .$width, .$my_name(), pos_stack)
   }


### PR DESCRIPTION
Stacking works fine and as expected whenever `ymin` values are greater than or equal to 0.
And stacking does not really make sense if `ymin < 0`, indeed.