### PR TITLE
Fixed typo in the documentation

### DIFF
--- a/R/stat-summary-2d.r
+++ b/R/stat-summary-2d.r
@@ -15,7 +15,7 @@
 #' }
 #'
 #' @seealso \code{\link{stat_summary_hex}} for hexagonal summarization. \code{\link{stat_bin2d}} for the binning options.
-#' @title Apply funciton for 2D rectangular bins.
+#' @title Apply function for 2D rectangular bins.
 #' @inheritParams stat_identity
 #' @param bins see \code{\link{stat_bin2d}}
 #' @param drop drop if the output of \code{fun} is \code{NA}.

--- a/R/stat-summary-hex.r
+++ b/R/stat-summary-hex.r
@@ -15,7 +15,7 @@
 ##' }
 ##'
 ##' @seealso \code{\link{stat_summary2d}} for rectangular summarization. \code{\link{stat_bin2d}} for the hexagon-ing options.
-##' @title Apply funciton for 2D hexagonal bins.
+##' @title Apply function for 2D hexagonal bins.
 ##' @inheritParams stat_identity
 ##' @param bins see \code{\link{stat_binhex}}
 ##' @param drop drop if the output of \code{fun} is \code{NA}.


### PR DESCRIPTION
There were typos in `stat_summary2d` and `stat_summary_hex` roxygen2 title tags, misspelling function *funciton*. 