### PR TITLE
layer.r: added missing error message newline/spacer

### DIFF
--- a/R/layer.r
+++ b/R/layer.r
@@ -159,7 +159,7 @@ Layer <- proto(expr = {
     wrong <- lengths != 1 & lengths != n
     if (any(wrong)) {
       stop("Aesthetics must either be length one, or the same length as the data",
-        "Problems:", paste(aesthetics[wrong], collapse = ", "), call. = FALSE)
+        "\nProblems:", paste(aesthetics[wrong], collapse = ", "), call. = FALSE)
     }
 
     if (empty(data) && n > 0) {

--- a/R/layer.r
+++ b/R/layer.r
@@ -158,7 +158,7 @@ Layer <- proto(expr = {
 
     wrong <- lengths != 1 & lengths != n
     if (any(wrong)) {
-      stop("Aesthetics must either be length one, or the same length as the data",
+      stop("Aesthetics must either be length one, or the same length as the data.",
         "\nProblems: ", paste(aesthetics[wrong], collapse = ", "), call. = FALSE)
     }
 

--- a/R/layer.r
+++ b/R/layer.r
@@ -159,7 +159,7 @@ Layer <- proto(expr = {
     wrong <- lengths != 1 & lengths != n
     if (any(wrong)) {
       stop("Aesthetics must either be length one, or the same length as the data",
-        "\nProblems:", paste(aesthetics[wrong], collapse = ", "), call. = FALSE)
+        "\nProblems: ", paste(aesthetics[wrong], collapse = ", "), call. = FALSE)
     }
 
     if (empty(data) && n > 0) {


### PR DESCRIPTION
Problem: 'stop' does not separate elements in the dots argument, therefore the error message (R/layer.r line 160f) is clumped:
Reproducible example:

```R
f <- function (a) ggplot(data.frame(x=rnorm(10),y=1:10), aes_q(x=quote(x),y=quote(y),color=a)) + geom_point()
f(1) # runs fine
f(1:3) # returns the error message:
Error: Aesthetics must either be length one, or the same length as the dataProblems:1:3

The fix would result in
...
f(1:3)
Error: Aesthetics must either be length one, or the same length as the data
Problems: 1:3
```