### PR TITLE
Improvements to scale_*_distiller

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -56,6 +56,9 @@ ggplot2 1.0.1
 
 * Fixes to pass `R CMD check --run-donttest` in R-devel.
 
+* Improvements in to order of colours and legend display of continuous colour
+  scales extracted from colorbrewer palettes in `scale_*_distiller()` (@jiho, 1076)
+
 ggplot2 1.0.0
 ----------------------------------------------------------------
 

--- a/R/scale-brewer.r
+++ b/R/scale-brewer.r
@@ -67,26 +67,26 @@ scale_fill_brewer <- function(..., type = "seq", palette = 1) {
 
 #' @export
 #' @rdname scale_brewer
-scale_colour_distiller <- function(..., type = "seq", palette = 1, values = NULL, space = "Lab", na.value = "grey50") {
+scale_colour_distiller <- function(..., type = "seq", palette = 1, values = NULL, space = "Lab", na.value = "grey50", guide = "colourbar") {
   # warn about using a qualitative brewer palette to generate the gradient
   type <- match.arg(type, c("seq", "div", "qual"))
   if (type == "qual") {
     warning("Using a discrete colour palette in a continuous scale.\n  Consider using type = \"seq\" or type = \"div\" instead", call. = FALSE)
   }
   continuous_scale("colour", "distiller",
-    gradient_n_pal(rev(brewer_pal(type, palette)(6)), values, space), na.value = na.value, ...)
+    gradient_n_pal(rev(brewer_pal(type, palette)(6)), values, space), na.value = na.value, guide = guide, ...)
   # NB: 6 colours per palette gives nice gradients; more results in more saturated colours which do not look as good
 }
 
 #' @export
 #' @rdname scale_brewer
-scale_fill_distiller <- function(..., type = "seq", palette = 1, values = NULL, space = "Lab", na.value = "grey50") {
+scale_fill_distiller <- function(..., type = "seq", palette = 1, values = NULL, space = "Lab", na.value = "grey50", guide = "colourbar") {
   type <- match.arg(type, c("seq", "div", "qual"))
   if (type == "qual") {
     warning("Using a discrete colour palette in a continuous scale.\n  Consider using type = \"seq\" or type = \"div\" instead", call. = FALSE)
   }
   continuous_scale("fill", "distiller",
-    gradient_n_pal(rev(brewer_pal(type, palette)(6)), values, space), na.value = na.value, ...)
+    gradient_n_pal(rev(brewer_pal(type, palette)(6)), values, space), na.value = na.value, guide = guide, ...)
 }
 
 # icon.brewer <- function() {

--- a/R/scale-brewer.r
+++ b/R/scale-brewer.r
@@ -74,7 +74,7 @@ scale_colour_distiller <- function(..., type = "seq", palette = 1, values = NULL
     warning("Using a discrete colour palette in a continuous scale.\n  Consider using type = \"seq\" or type = \"div\" instead", call. = FALSE)
   }
   continuous_scale("colour", "distiller",
-    gradient_n_pal(brewer_pal(type, palette)(6), values, space), na.value = na.value, ...)
+    gradient_n_pal(rev(brewer_pal(type, palette)(6)), values, space), na.value = na.value, ...)
   # NB: 6 colours per palette gives nice gradients; more results in more saturated colours which do not look as good
 }
 
@@ -86,7 +86,7 @@ scale_fill_distiller <- function(..., type = "seq", palette = 1, values = NULL, 
     warning("Using a discrete colour palette in a continuous scale.\n  Consider using type = \"seq\" or type = \"div\" instead", call. = FALSE)
   }
   continuous_scale("fill", "distiller",
-    gradient_n_pal(brewer_pal(type, palette)(6), values, space), na.value = na.value, ...)
+    gradient_n_pal(rev(brewer_pal(type, palette)(6)), values, space), na.value = na.value, ...)
 }
 
 # icon.brewer <- function() {

--- a/man/scale_brewer.Rd
+++ b/man/scale_brewer.Rd
@@ -14,15 +14,15 @@ scale_colour_brewer(..., type = "seq", palette = 1)
 scale_fill_brewer(..., type = "seq", palette = 1)
 
 scale_colour_distiller(..., type = "seq", palette = 1, values = NULL,
-  space = "Lab", na.value = "grey50")
+  space = "Lab", na.value = "grey50", guide = "colourbar")
 
 scale_fill_distiller(..., type = "seq", palette = 1, values = NULL,
-  space = "Lab", na.value = "grey50")
+  space = "Lab", na.value = "grey50", guide = "colourbar")
 
 scale_color_brewer(..., type = "seq", palette = 1)
 
 scale_color_distiller(..., type = "seq", palette = 1, values = NULL,
-  space = "Lab", na.value = "grey50")
+  space = "Lab", na.value = "grey50", guide = "colourbar")
 }
 \arguments{
 \item{...}{Other arguments passed on to \code{\link{discrete_scale}}
@@ -42,6 +42,9 @@ to map an arbitrary range to between 0 and 1.}
 best unless gradient goes through white.}
 
 \item{na.value}{Colour to use for missing values}
+
+\item{guide}{Type of legend. Use \code{"colourbar"} for continuous
+colour bar, or \code{"legend"} for discrete colour legend.}
 }
 \description{
 ColorBrewer provides sequential, diverging and qualitative colour schemes


### PR DESCRIPTION
The order of colors in particular, and the fact that it cannot be easily
reversed (pending a change in package scales) makes scale_*_distiller
almost useless at the moment.

These are simple fixes and should be easy to pull.