### PR TITLE
Remove tick marks from theme_minimal

### DIFF
--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -177,7 +177,8 @@ theme_minimal <- function(base_size = 12, base_family = "") {
       panel.background  = element_blank(),
       panel.border      = element_blank(),
       strip.background  = element_blank(),
-      plot.background   = element_blank()
+      plot.background   = element_blank(),
+      axis.ticks        = element_blank()
     )
 }
 


### PR DESCRIPTION
A very minor change: I've removed tick marks from ` theme_minimal() ` as I think that is more in keeping with "minimalism". The black ticks seemed a little visually unnecessary. 

Incidentally, removing black ticks it also aligns minimal to the default plotly theme.

All good if you don't like the idea.

```r 
qplot(data = mtcars, x = mpg, y = wt) + theme_minimal() 
```
Before:
![before](https://cloud.githubusercontent.com/assets/9009228/7114958/e478eff6-e1da-11e4-87aa-bc586ef6f158.png)

After:
![after](https://cloud.githubusercontent.com/assets/9009228/7114961/eaa73662-e1da-11e4-9913-f4008e215118.png)

Tom