### PR TITLE
Add linewidth option geom_path and geom_point.

### DIFF
--- a/R/geom-path-.r
+++ b/R/geom-path-.r
@@ -167,7 +167,7 @@ GeomPath <- proto(Geom, {
           default.units="native", arrow = arrow,
           gp = gpar(
             col = alpha(colour, alpha)[!end], fill = alpha(colour, alpha)[!end],
-            lwd = size[!end] * .pt, lty = linetype[!end],
+            lwd = size[!end] * linewidth * .pt, lty = linetype[!end],
             lineend = lineend, linejoin = linejoin, linemitre = linemitre
           )
         )
@@ -180,7 +180,7 @@ GeomPath <- proto(Geom, {
           default.units = "native", arrow = arrow,
           gp = gpar(
             col = alpha(colour, alpha)[start], fill = alpha(colour, alpha)[start],
-            lwd = size[start] * .pt, lty = linetype[start],
+            lwd = size[start] * linewidth * .pt, lty = linetype[start],
             lineend = lineend, linejoin = linejoin, linemitre = linemitre)
         )
       )
@@ -200,7 +200,7 @@ GeomPath <- proto(Geom, {
 
   default_stat <- function(.) StatIdentity
   required_aes <- c("x", "y")
-  default_aes <- function(.) aes(colour="black", size=0.5, linetype=1, alpha = NA)
+  default_aes <- function(.) aes(colour="black", size=0.5, linetype=1, alpha = NA, linewidth = 1)
   guide_geom <- function(.) "path"
 
 })

--- a/R/geom-point-.r
+++ b/R/geom-point-.r
@@ -119,7 +119,7 @@ GeomPoint <- proto(Geom, {
 
     with(coord_transform(coordinates, data, scales),
       ggname(.$my_name(), pointsGrob(x, y, size=unit(size, "mm"), pch=shape,
-      gp=gpar(col=alpha(colour, alpha), fill = alpha(fill, alpha), fontsize = size * .pt)))
+      gp=gpar(col=alpha(colour, alpha), fill = alpha(fill, alpha), fontsize = size * .pt, lwd=linewidth)))
     )
   }
 
@@ -138,6 +138,6 @@ GeomPoint <- proto(Geom, {
 
   default_stat <- function(.) StatIdentity
   required_aes <- c("x", "y")
-  default_aes <- function(.) aes(shape=16, colour="black", size=2, fill = NA, alpha = NA)
+  default_aes <- function(.) aes(shape=16, colour="black", size=2, fill = NA, alpha = NA, linewidth=2)
 
 })


### PR DESCRIPTION
This PR adds an aesthetic option to `geom_point` and `geom_path` (and its derivatives, such as `geom_line`) to customize the width of the lines drawn (by passing the `linewidth` property). This is implemented by simply delegating to the `lwd` option of the `grid` library.