### PR TITLE
Fix how geom_dotplot handles some aes

### DIFF
--- a/R/geom-dotplot.r
+++ b/R/geom-dotplot.r
@@ -173,10 +173,6 @@ GeomDotplot <- proto(Geom, {
       stackaxismax <- .5
     }
 
-
-    # Fill the bins: at a given x (or y), if count=3, make 3 entries at that x
-    df <- df[rep(1:nrow(df), df$count), ]
-
     # Next part will set the position of each dot within each stack
     # If stackgroups=TRUE, split only on x (or y) and panel; if not stacking, also split by group
     plyvars <- params$binaxis %||% "x"


### PR DESCRIPTION
This commit allows geom_dotplot to display color attributes properly
when dots are binned.  Prior to this, if one ran a command such as:

    ggplot(mtcars, aes(x=factor(cyl), y =mpg, fill=factor(carb), group=factor(cyl))) + geom_dotplot(binaxis="y", stackdir="center")

The dots would be positioned on top of each other, because a "double
grouping" was performed where both the fill and the x axis were used to
divide groups.  This change keeps the groups appropriately separated
when the x/y positions are being determined, but still applies separate
coloring to each.

It does this by changing where the fill color is added to the data used
when plotting.  Previously, the data was condensed into bins and a
dataframe where each row represented several dots to be plotted during
the calculate groups step. This condendsed data was then re-expanded
with a constant fill color added for each binned group inside the
reparameterise method.  This commit re-expands the data into one line
per dot in the original calculate method, where the appropriate fill
(or other aes) is still available and can be added back in.

I verified that all the original examples for geom_dotplot still behave
as expected, and all tests currently pass.