### PR TITLE
Example of stat_bin2d with a log-scaled axis

### DIFF
--- a/man/stat_bin2d.Rd
+++ b/man/stat_bin2d.Rd
@@ -56,6 +56,11 @@ x <- seq(min(diamonds$carat), max(diamonds$carat), by = 0.1)
 y <- seq(min(diamonds$price), max(diamonds$price), length = 50)
 d + stat_bin2d(breaks = list(x = x, y = y))
 
+# Or with a list of breaks, on a semi-log plot
+log_price_range <- log10(range(diamonds$price))
+ylog <- seq(log_price_range[1], log_price_range[2], length=50)
+d + scale_y_log10() + stat_bin2d(breaks = list(x = x, y = ylog))
+
 # With qplot
 qplot(x, y, data = diamonds, geom="bin2d",
   xlim = c(4, 10), ylim = c(4, 10))


### PR DESCRIPTION
I couldn't find an example of this anywhere, and it took me an hour to figure out, so I thought maybe it belonged in the documentation. I'm not sure if anyone else is trying to do this, though.

Here's the image that the added example generates:

![semilog](https://cloud.githubusercontent.com/assets/229502/8087163/5a0a3cd4-0f67-11e5-97f4-9c8bbbcf8e25.png)

And here's the current help page: <http://docs.ggplot2.org/current/stat_bin2d.html>