### PR TITLE
Handle stat_bin2d(breaks=(x=NA,y=Something))

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,9 @@ ggplot2 1.0.1.9xxx
   that would allocated for it) with `NULL` in the `scale_` function. To
   use the default lable, use `waiver()` (#1145).
 
+* `geom_bin2d()` will now let you specify one dimension's breaks exactly,
+  without touching the other dimension's default breaks at all (#1126).
+
 * `labels = NULL` now works with `guide_legend()` and `guide_colorbar()`.
   (#1175, #1183).
 

--- a/R/stat-bin2d.r
+++ b/R/stat-bin2d.r
@@ -33,6 +33,10 @@ StatBin2d <- proto2("StatBin2d", Stat,
       y = scale_dimension(scales$y, c(0, 0))
     )
 
+    # is.integer(...) below actually deals with factor input data, which is
+    # integer by now.  Bins for factor data should take the width of one level,
+    # and should show up centered over their tick marks.
+
     # Determine origin, if omitted
     if (is.null(origin)) {
       origin <- c(NA, NA)
@@ -63,16 +67,21 @@ StatBin2d <- proto2("StatBin2d", Stat,
 
     # Determine breaks, if omitted
     if (is.null(breaks)) {
-      breaks <- list(
-        seq(origin[1], max(range$x) + binwidth[1], binwidth[1]),
-        seq(origin[2], max(range$y) + binwidth[2], binwidth[2])
-      )
-    } else {
-      stopifnot(is.list(breaks))
-      stopifnot(length(breaks) == 2)
-      stopifnot(all(sapply(breaks, is.numeric)))
+      breaks <- list(x = NULL, y = NULL)
     }
+
+    stopifnot(length(breaks) == 2)
     names(breaks) <- c("x", "y")
+
+    if (is.null(breaks$x)) {
+      breaks$x <- seq(origin[1], max(range$x) + binwidth[1], binwidth[1])
+    }
+    if (is.null(breaks$y)) {
+      breaks$y <- seq(origin[2], max(range$y) + binwidth[2], binwidth[2])
+    }
+
+    stopifnot(is.list(breaks))
+    stopifnot(all(sapply(breaks, is.numeric)))
 
     xbin <- cut(data$x, sort(breaks$x), include.lowest = TRUE)
     ybin <- cut(data$y, sort(breaks$y), include.lowest = TRUE)

--- a/man/geom_bin2d.Rd
+++ b/man/geom_bin2d.Rd
@@ -69,6 +69,13 @@ d + geom_bin2d(bins = 30)
 
 # Or by specifying the width of the bins
 d + geom_bin2d(binwidth = c(0.1, 0.1))
+
+# Or with a list of breaks (NULL to generate one dimension the default
+# way)
+x <- seq(min(diamonds$carat), max(diamonds$carat), by = 0.1)
+y <- seq(min(diamonds$price), max(diamonds$price), length = 50)
+d + geom_bin2d(breaks = list(x = x, y = y))
+d + geom_bin2d(breaks = list(x = x, y = NULL))
 }
 \seealso{
 \code{\link{stat_binhex}} for hexagonal binning

--- a/tests/testthat/test-stats.r
+++ b/tests/testthat/test-stats.r
@@ -113,6 +113,56 @@ test_that("stat-bin2d", {
                       y = scale_y_continuous(limits = range(d$depth, na.rm=TRUE)))
   ret <- test_stat_scale(stat_bin2d(aes(x = carat, y = depth), data=d), full_scales)
   expect_equal(dim(ret), c(191,12))
+
+  breaks <- list(x = seq(min(d$carat, na.rm=TRUE),
+                         max(d$carat, na.rm=TRUE), length.out=41),
+                 y = NULL)
+  ret <- test_stat_scale(stat_bin2d(aes(x = carat, y = depth),
+                                    data=d, breaks=breaks), full_scales)
+  expect_equal(length(levels(ret$xbin)), 40)
+  expect_equal(length(levels(ret$ybin)), 31)
+  expect_equal(dim(ret), c(230,12))
+})
+
+test_that(
+  "stat_bin2d(breaks=...)",
+{
+  df <- data.frame(x = 0:3, y = 0:3)
+
+  g <- ggplot(df, aes(x, y))
+
+  # Test explicitly setting the breaks for x, overriding
+  # the binwidth.
+  integer_breaks <- (0:4) - 0.5  # Will use for x
+  half_breaks <- seq(0, 3.5, 0.5)  # Will test against this for y
+
+  got <- ggplot_build(
+    g + stat_bin2d(breaks = list(x = integer_breaks, y = NULL),
+                   binwidth=c(0.5, 0.5)))
+
+  expect_equal(got$data[[1]]$xmin, (0:3) - 0.5)
+  expect_equal(got$data[[1]]$xmax, (0:3) + 0.5)
+  expect_equal(got$data[[1]]$xbin,
+               cut(df$x, integer_breaks, include.lowest = TRUE))
+
+  expect_equal(got$data[[1]]$ybin,
+               cut(df$y, half_breaks, include.lowest = TRUE))
+
+  # Test that we can get the same results with binwidth= and
+  # with breaks=.
+  expected <- ggplot_build(g + stat_bin2d(binwidth=c(0.5, 0.5)))
+
+  breaks_to_try <- list(
+    list(x = half_breaks, y = half_breaks),
+    list(x = half_breaks, y = NULL),
+    list(x = NULL, y = half_breaks),
+    list(x = NULL, y = NULL))
+
+  for (breaks in breaks_to_try) {
+    got <- ggplot_build(g + stat_bin2d(breaks = breaks, binwidth=c(0.5, 0.5)))
+
+    expect_equal(got$data[[1]], expected$data[[1]])
+  }
 })
 
 


### PR DESCRIPTION
With this change, you can specify one set of breaks to `stat_bin2d` without setting the other.  This is particularly useful when binning by date in one dimension, and using a transformed scale in the other dimension.  This way, you don't have to figure out how to reconstruct the default breaks for the transformed scale.  For example:

```r
breaks <- list( x = sort(unique(movies$year)) - 0.5, y = NA )
g <- ggplot(movies) + aes(x = year, y = length)
g + stat_bin2d(breaks=breaks) + scale_y_log10()
```