### PR TITLE
Add stroke option to geom_point.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -105,6 +105,9 @@ ggplot2 1.0.1.9000
   (e.g., gridlines) on top of data. Usually used with blank or transparent
   `panel.background`.  (@noamross. #551)
 
+* Add `stroke` aesthetic to `geom_point` controlling the stroke width of the
+  border for shape types 21 - 25 (#1133, @SeySayux)
+
 ggplot2 1.0.1
 ----------------------------------------------------------------
 

--- a/R/geom-boxplot.r
+++ b/R/geom-boxplot.r
@@ -26,6 +26,7 @@
 #' @param outlier.colour colour for outlying points. Uses the default from geom_point().
 #' @param outlier.shape shape of outlying points. Uses the default from geom_point().
 #' @param outlier.size size of outlying points. Uses the default from geom_point().
+#' @param outlier.stroke stroke width of outlying points. Uses the default from geom_point().
 #' @param notch if \code{FALSE} (default) make a standard box plot. If
 #'    \code{TRUE}, make a notched box plot. Notches are used to compare groups;
 #'    if the notches of two boxes do not overlap, this is strong evidence that
@@ -109,19 +110,21 @@
 geom_boxplot <- function (mapping = NULL, data = NULL, stat = "boxplot",
                           position = "dodge", outlier.colour = NULL,
                           outlier.shape = NULL, outlier.size = NULL,
-                          notch = FALSE, notchwidth = .5, varwidth = FALSE,
-                          show_guide = NA,...) {
+                          outlier.stroke = 1, notch = FALSE, notchwidth = .5,
+                          varwidth = FALSE, show_guide = NA,...) {
 
   outlier_defaults <- Geom$find('point')$default_aes()
 
   outlier.colour   <- outlier.colour %||% outlier_defaults$colour
   outlier.shape    <- outlier.shape  %||% outlier_defaults$shape
   outlier.size     <- outlier.size   %||% outlier_defaults$size
+  outlier.stroke   <- outlier.stroke %||% outlier_defaults$stroke
 
   GeomBoxplot$new(mapping = mapping, data = data, stat = stat,
     position = position, outlier.colour = outlier.colour,
-    outlier.shape = outlier.shape, outlier.size = outlier.size, notch = notch,
-    notchwidth = notchwidth, varwidth = varwidth, show_guide = show_guide,...)
+    outlier.shape = outlier.shape, outlier.size = outlier.size,
+    outlier.stoke = outlier.stroke, notch = notch, notchwidth = notchwidth,
+    varwidth = varwidth, show_guide = show_guide,...)
 }
 
 GeomBoxplot <- proto(Geom, {
@@ -157,7 +160,7 @@ GeomBoxplot <- proto(Geom, {
     df
   }
 
-  draw <- function(., data, ..., fatten = 2, outlier.colour = NULL, outlier.shape = NULL, outlier.size = 2,
+  draw <- function(., data, ..., fatten = 2, outlier.colour = NULL, outlier.shape = NULL, outlier.size = 2, outlier.stroke = 1,
                    notch = FALSE, notchwidth = .5, varwidth = FALSE) {
     common <- data.frame(
       colour = data$colour,
@@ -195,6 +198,7 @@ GeomBoxplot <- proto(Geom, {
         colour = outlier.colour %||% data$colour[1],
         shape = outlier.shape %||% data$shape[1],
         size = outlier.size %||% data$size[1],
+        stroke = outlier.stroke %||% data$stroke[1],
         fill = NA,
         alpha = NA,
         stringsAsFactors = FALSE)

--- a/R/geom-point-.r
+++ b/R/geom-point-.r
@@ -82,6 +82,10 @@
 #' d + geom_point(alpha = 1/20)
 #' d + geom_point(alpha = 1/100)
 #'
+#' # Using shapes with a border
+#' p <- ggplot(mtcars, aes(wt, mpg))
+#' p + geom_point(shape=21, size=5, colour='black', fill='white', stroke=4)
+#'
 #' # You can create interesting shapes by layering multiple points of
 #' # different sizes
 #' p <- ggplot(mtcars, aes(mpg, wt))
@@ -125,7 +129,7 @@ GeomPoint <- proto(Geom, {
 
     with(coord_transform(coordinates, data, scales),
       ggname(.$my_name(), pointsGrob(x, y, size=unit(size, "mm"), pch=shape,
-      gp=gpar(col=alpha(colour, alpha), fill = alpha(fill, alpha), fontsize = size * .pt)))
+      gp=gpar(col=alpha(colour, alpha), fill = alpha(fill, alpha), lwd = stroke, fontsize = size * .pt)))
     )
   }
 
@@ -137,13 +141,14 @@ GeomPoint <- proto(Geom, {
       gp=gpar(
         col=alpha(colour, alpha),
         fill=alpha(fill, alpha),
-        fontsize = size * .pt)
+        lwd=stroke,
+        fontsize = size * .pt),
       )
     )
   }
 
   default_stat <- function(.) StatIdentity
   required_aes <- c("x", "y")
-  default_aes <- function(.) aes(shape=16, colour="black", size=2, fill = NA, alpha = NA)
+  default_aes <- function(.) aes(shape=16, colour="black", size=2, fill = NA, alpha = NA, stroke = 1)
 
 })

--- a/R/geom-pointrange.r
+++ b/R/geom-pointrange.r
@@ -21,7 +21,7 @@ GeomPointrange <- proto(Geom, {
   objname <- "pointrange"
 
   default_stat <- function(.) StatIdentity
-  default_aes <- function(.) aes(colour = "black", size=0.5, linetype=1, shape=16, fill=NA, alpha = NA)
+  default_aes <- function(.) aes(colour = "black", size=0.5, linetype=1, shape=16, fill=NA, alpha = NA, stroke = 1)
   guide_geom <- function(.) "pointrange"
   required_aes <- c("x", "y", "ymin", "ymax")
 

--- a/man/geom_boxplot.Rd
+++ b/man/geom_boxplot.Rd
@@ -6,8 +6,8 @@
 \usage{
 geom_boxplot(mapping = NULL, data = NULL, stat = "boxplot",
   position = "dodge", outlier.colour = NULL, outlier.shape = NULL,
-  outlier.size = NULL, notch = FALSE, notchwidth = 0.5,
-  varwidth = FALSE, show_guide = NA, ...)
+  outlier.size = NULL, outlier.stroke = 1, notch = FALSE,
+  notchwidth = 0.5, varwidth = FALSE, show_guide = NA, ...)
 }
 \arguments{
 \item{mapping}{The aesthetic mapping, usually constructed with
@@ -28,6 +28,8 @@ a call to a position adjustment function.}
 \item{outlier.shape}{shape of outlying points. Uses the default from geom_point().}
 
 \item{outlier.size}{size of outlying points. Uses the default from geom_point().}
+
+\item{outlier.stroke}{stroke width of outlying points. Uses the default from geom_point().}
 
 \item{notch}{if \code{FALSE} (default) make a standard box plot. If
 \code{TRUE}, make a notched box plot. Notches are used to compare groups;

--- a/man/geom_point.Rd
+++ b/man/geom_point.Rd
@@ -95,6 +95,10 @@ d + geom_point(alpha = 1/10)
 d + geom_point(alpha = 1/20)
 d + geom_point(alpha = 1/100)
 
+# Using shapes with a border
+p <- ggplot(mtcars, aes(wt, mpg))
+p + geom_point(shape=21, size=5, colour='black', fill='white', stroke=4)
+
 # You can create interesting shapes by layering multiple points of
 # different sizes
 p <- ggplot(mtcars, aes(mpg, wt))


### PR DESCRIPTION
This PR adds an aesthetic option `stroke` to `geom_point` that makes it possible to specify the stroke width of point shapes 21-25 (see #1085, I had to resubmit because you can't force push when an issue is closed).