### PR TITLE
Fix all found instances of partial matching

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 ggplot2 1.0.1.9000
 ----------------------------------------------------------------
 
+* All instances of partial matched dollar expressions were removed (@jimhester,
+  #1134)
+
 * `geom_text()` gains `nudge_x` and `nudge_y` arguments to offset labels from
   the x & y position (#1120). `check_overlap = TRUE` provides a simple
   resolution to label overplotting (#1039).

--- a/R/facet-grid-.r
+++ b/R/facet-grid-.r
@@ -361,8 +361,8 @@ facet_panels.grid <- function(facet, panel, coord, theme, geom_grobs) {
   nrow <- max(panel$layout$ROW)
 
   panel_grobs <- lapply(panels, function(i) {
-    fg <- coord_render_fg(coord, panel$range[[i]], theme)
-    bg <- coord_render_bg(coord, panel$range[[i]], theme)
+    fg <- coord_render_fg(coord, panel$ranges[[i]], theme)
+    bg <- coord_render_bg(coord, panel$ranges[[i]], theme)
 
     geom_grobs <- lapply(geom_grobs, "[[", i)
     panel_grobs <- c(list(bg), geom_grobs, list(fg))
@@ -380,14 +380,14 @@ facet_panels.grid <- function(facet, panel, coord, theme, geom_grobs) {
   # In general, panel has all information for building facet.
   if (facet$space_free$x) {
     ps <- panel$layout$PANEL[panel$layout$ROW == 1]
-    widths <- vapply(ps, function(i) diff(panel$range[[i]]$x.range), numeric(1))
+    widths <- vapply(ps, function(i) diff(panel$ranges[[i]]$x.range), numeric(1))
     panel_widths <- unit(widths, "null")
   } else {
     panel_widths <- rep(unit(1, "null"), ncol)
   }
   if (facet$space_free$y) {
     ps <- panel$layout$PANEL[panel$layout$COL == 1]
-    heights <- vapply(ps, function(i) diff(panel$range[[i]]$y.range), numeric(1))
+    heights <- vapply(ps, function(i) diff(panel$ranges[[i]]$y.range), numeric(1))
     panel_heights <- unit(heights, "null")
   } else {
     panel_heights <- rep(unit(1 * aspect_ratio, "null"), nrow)

--- a/R/facet-wrap.r
+++ b/R/facet-wrap.r
@@ -195,8 +195,8 @@ facet_render.wrap <- function(facet, panel, coord, theme, geom_grobs) {
 facet_panels.wrap <- function(facet, panel, coord, theme, geom_grobs) {
   panels <- panel$layout$PANEL
   lapply(panels, function(i) {
-    fg <- coord_render_fg(coord, panel$range[[i]], theme)
-    bg <- coord_render_bg(coord, panel$range[[i]], theme)
+    fg <- coord_render_fg(coord, panel$ranges[[i]], theme)
+    bg <- coord_render_bg(coord, panel$ranges[[i]], theme)
 
     geom_grobs <- lapply(geom_grobs, "[[", i)
     panel_grobs <- c(list(bg), geom_grobs, list(fg))
@@ -223,7 +223,7 @@ facet_axes.wrap <- function(facet, panel, coord, theme) {
   axes <- list()
   axes$b <- lapply(panels, function(i) {
     if (panel$layout$AXIS_X[i]) {
-      grob <- coord_render_axis_h(coord, panel$range[[i]], theme)
+      grob <- coord_render_axis_h(coord, panel$ranges[[i]], theme)
     } else {
       grob <- zeroGrob()
     }
@@ -232,7 +232,7 @@ facet_axes.wrap <- function(facet, panel, coord, theme) {
 
   axes$l <- lapply(panels, function(i) {
     if (panel$layout$AXIS_Y[i]) {
-      grob <- coord_render_axis_v(coord, panel$range[[i]], theme)
+      grob <- coord_render_axis_v(coord, panel$ranges[[i]], theme)
     } else {
       grob <- zeroGrob()
     }

--- a/R/plot-render.r
+++ b/R/plot-render.r
@@ -26,7 +26,7 @@ ggplot_gtable <- function(data) {
 
     dlply(layer_data, "PANEL", function(df) {
       panel_i <- match(df$PANEL[1], panel$layout$PANEL)
-      layer$make_grob(df, scales = panel$ranges[[panel_i]], cs = plot$coord)
+      layer$make_grob(df, scales = panel$ranges[[panel_i]], cs = plot$coordinates)
     }, .drop = FALSE)
   }
 
@@ -44,7 +44,7 @@ ggplot_gtable <- function(data) {
   }
 
   # List by layer, list by panel
-  geom_grobs <- Map(build_grob, plot$layer, data)
+  geom_grobs <- Map(build_grob, plot$layers, data)
 
   plot_table <- facet_render(plot$facet, panel, plot$coordinates,
     plot_theme(plot), geom_grobs)

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -96,7 +96,7 @@ continuous_scale <- function(aesthetics, scale_name, palette, name = NULL, break
 
   trans <- as.trans(trans)
   if (!is.null(limits)) {
-    limits <- trans$trans(limits)
+    limits <- trans$transform(limits)
   }
 
   structure(list(
@@ -254,7 +254,7 @@ scale_transform <- function(scale, x) UseMethod("scale_transform")
 
 #' @export
 scale_transform.continuous <- function(scale, x) {
-  scale$trans$trans(x)
+  scale$trans$transform(x)
 }
 #' @export
 scale_transform.discrete <- function(scale, x) {
@@ -373,7 +373,7 @@ scale_breaks <- function(scale, limits = scale_limits(scale)) {
 #' @export
 scale_breaks.continuous <- function(scale, limits = scale_limits(scale)) {
   # Limits in transformed space need to be converted back to data space
-  limits <- scale$trans$inv(limits)
+  limits <- scale$trans$inverse(limits)
 
   if (is.null(scale$breaks)) {
     return(NULL)
@@ -395,7 +395,7 @@ scale_breaks.continuous <- function(scale, limits = scale_limits(scale)) {
   # @kohske
   # TODO: replace NA with something else for flag.
   #       guides cannot discriminate oob from missing value.
-  breaks <- censor(scale$trans$trans(breaks), scale$trans$trans(limits))
+  breaks <- censor(scale$trans$transform(breaks), scale$trans$transform(limits))
   if (length(breaks) == 0) {
     stop("Zero breaks in scale for ", paste(scale$aesthetics, collapse = "/"),
       call. = FALSE)
@@ -456,8 +456,8 @@ scale_breaks_minor.continuous <- function(scale, n = 2, b = scale_break_position
     }
   } else if (is.function(scale$minor_breaks)) {
     # Find breaks in data space, and convert to numeric
-    breaks <- scale$minor_breaks(scale$trans$inv(limits))
-    breaks <- scale$trans$trans(breaks)
+    breaks <- scale$minor_breaks(scale$trans$inverse(limits))
+    breaks <- scale$trans$transform(breaks)
   } else {
     breaks <- scale$minor_breaks
   }
@@ -483,7 +483,7 @@ scale_labels <- function(scale, breaks = scale_breaks(scale)) {
 scale_labels.continuous <- function(scale, breaks = scale_breaks(scale)) {
   if (is.null(breaks)) return(NULL)
 
-  breaks <- scale$trans$inv(breaks)
+  breaks <- scale$trans$inverse(breaks)
 
   if (is.null(scale$labels)) {
     return(NULL)

--- a/inst/tests/helper-plot-data.r
+++ b/inst/tests/helper-plot-data.r
@@ -7,8 +7,8 @@ cdata <- function(plot) {
   lapply(pieces$data, function(d) {
     ddply(d, "PANEL", function(panel_data) {
       scales <- panel_scales(pieces$panel, panel_data$PANEL[1])
-      details <- coord_train(plot$coord, scales)
-      coord_transform(plot$coord, panel_data, details)
+      details <- coord_train(plot$coordinates, scales)
+      coord_transform(plot$coordinates, panel_data, details)
     })
   })
 }


### PR DESCRIPTION
These were found by setting

```
options(warnPartialMatchAttr = TRUE,
    warnPartialMatchDollar = TRUE,
    warn = 2)
```

Using hadley/testthat#269 with `options("testthat.suppress" = NULL)` and running
`devtools::test()` and `vtest::vtest()` until there were no more partial
match messages.

There may still be some instances in the code base, but I think this
finds the vast majority.