### PR TITLE
rename aes in override.aes to allow for american spellings

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -127,6 +127,8 @@ ggplot2 1.0.1.9xxx
 * Add `stroke` aesthetic to `geom_point` controlling the stroke width of the
   border for shape types 21 - 25 (#1133, @SeySayux)
 
+* `override.aes` now works with American aesthetic spelling, e.g. color
+
 ggplot2 1.0.1
 ----------------------------------------------------------------
 

--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -280,6 +280,7 @@ guide_geom.legend <- function(guide, layers, default_mapping) {
     if (is.null(data)) return(NULL)
 
     # override.aes in guide_legend manually changes the geom
+    guide$override.aes <- rename_aes(guide$override.aes)
     for (aes in intersect(names(guide$override.aes), names(data))) data[[aes]] <- guide$override.aes[[aes]]
 
     geom <- Geom$find(layer$geom$guide_geom())


### PR DESCRIPTION
A small change to allow for:

    p <- ggplot(mtcars,aes(x = mpg,y = disp,size = cyl)) + geom_point()
    p + scale_size_continuous(guide = guide_legend(override.aes(color = "red")))