### PR TITLE
Don't attach plyr in tests

### DIFF
--- a/tests/testthat/test-aes-grouping.r
+++ b/tests/testthat/test-aes-grouping.r
@@ -5,7 +5,6 @@ df <- data.frame(
   a = c("a", "a", "b", "b"),
   b = c("a", "b", "a", "b")
 )
-library(plyr)
 
 group <- function(x) pdata(x)[[1]]$group
 groups <- function(x) length(unique(group(x)))
@@ -50,7 +49,7 @@ test_that("order affects plotting order of points", {
   ord1 <- ggplot_build(base)$data[[1]]
   ord2 <- ggplot_build(base + aes(order = x))$data[[1]]
   rev1 <- ggplot_build(base + aes(order = -x))$data[[1]]
-  rev2 <- ggplot_build(base + aes(order = desc(x)))$data[[1]]
+  rev2 <- ggplot_build(base + aes(order = plyr::desc(x)))$data[[1]]
 
   expect_equal(ord1$y, 1:4)
   expect_equal(ord2$y, 1:4)
@@ -63,7 +62,7 @@ test_that("order affects plotting order of bars", {
 
   ord1 <- ggplot_build(base)$data[[1]]
   ord2 <- ggplot_build(base + aes(order = a))$data[[1]]
-  rev1 <- ggplot_build(base + aes(order = desc(b)))$data[[1]]
+  rev1 <- ggplot_build(base + aes(order = plyr::desc(b)))$data[[1]]
 
   expect_equal(ord1$group, 1:4)
   expect_equal(ord2$group, 1:4)

--- a/tests/testthat/test-scales-breaks-labels.r
+++ b/tests/testthat/test-scales-breaks-labels.r
@@ -7,7 +7,6 @@ test_that("labels match breaks, even when outside limits", {
   expect_equal(scale_labels(sc), 1:4)
   expect_equal(scale_breaks_minor(sc), c(1, 1.5, 2, 2.5, 3))
 })
-.
 
 test_that("labels must match breaks", {
   expect_that(scale_x_discrete(breaks = 1:3, labels = 1:2),


### PR DESCRIPTION
Only two tests needed to be adapted after removing `library(plyr)`