### PR TITLE
Use group identifier -1 if no group aesthetic is specified

### DIFF
--- a/R/utilities-layer.r
+++ b/R/utilities-layer.r
@@ -4,7 +4,8 @@ NO_GROUP <- -1L
 #
 # If the \code{group} variable is not present, then a new group
 # variable is generated from the interaction of all discrete (factor or
-# character) vectors, excluding \code{label}.
+# character) vectors, excluding \code{label}. The special value \code{NO_GROUP}
+# is used for all observations if no discrete variables exist.
 #
 # @param data.frame
 # @value data.frame with group variable

--- a/R/utilities-layer.r
+++ b/R/utilities-layer.r
@@ -17,7 +17,7 @@ add_group <- function(data) {
     if (any(disc)) {
       data$group <- plyr::id(data[disc], drop = TRUE)
     } else {
-      data$group <- 1L
+      data$group <- 0L
     }
   } else {
     data$group <- plyr::id(data["group"], drop = TRUE)

--- a/R/utilities-layer.r
+++ b/R/utilities-layer.r
@@ -1,3 +1,5 @@
+NO_GROUP <- -1L
+
 # Ensure that the data frame contains a grouping variable.
 #
 # If the \code{group} variable is not present, then a new group
@@ -17,7 +19,7 @@ add_group <- function(data) {
     if (any(disc)) {
       data$group <- plyr::id(data[disc], drop = TRUE)
     } else {
-      data$group <- 0L
+      data$group <- NO_GROUP
     }
   } else {
     data$group <- plyr::id(data["group"], drop = TRUE)

--- a/tests/testthat/test-aes-grouping.r
+++ b/tests/testthat/test-aes-grouping.r
@@ -12,7 +12,7 @@ groups <- function(x) length(unique(group(x)))
 
 test_that("one group per combination of discrete vars", {
   plot <- ggplot(df, aes(x, x)) + geom_point()
-  expect_that(group(plot), equals(c(0, 0, 0, 0)))
+  expect_that(group(plot), equals(rep(NO_GROUP, 4)))
 
   plot <- ggplot(df, aes(x, a)) + geom_point()
   expect_that(group(plot), equals(c(1, 1, 2, 2)))
@@ -25,7 +25,7 @@ test_that("one group per combination of discrete vars", {
 
 test_that("label is not used as a grouping var", {
   plot <- ggplot(df, aes(x, x, label = a)) + geom_point()
-  expect_that(group(plot), equals(c(0, 0, 0, 0)))
+  expect_that(group(plot), equals(rep(NO_GROUP, 4)))
 
   plot <- ggplot(df, aes(x, x, colour = a, label = b)) + geom_point()
   expect_that(group(plot), equals(c(1, 1, 2, 2)))

--- a/tests/testthat/test-aes-grouping.r
+++ b/tests/testthat/test-aes-grouping.r
@@ -12,7 +12,7 @@ groups <- function(x) length(unique(group(x)))
 
 test_that("one group per combination of discrete vars", {
   plot <- ggplot(df, aes(x, x)) + geom_point()
-  expect_that(group(plot), equals(c(1, 1, 1, 1)))
+  expect_that(group(plot), equals(c(0, 0, 0, 0)))
 
   plot <- ggplot(df, aes(x, a)) + geom_point()
   expect_that(group(plot), equals(c(1, 1, 2, 2)))
@@ -25,7 +25,7 @@ test_that("one group per combination of discrete vars", {
 
 test_that("label is not used as a grouping var", {
   plot <- ggplot(df, aes(x, x, label = a)) + geom_point()
-  expect_that(group(plot), equals(c(1, 1, 1, 1)))
+  expect_that(group(plot), equals(c(0, 0, 0, 0)))
 
   plot <- ggplot(df, aes(x, x, colour = a, label = b)) + geom_point()
   expect_that(group(plot), equals(c(1, 1, 2, 2)))


### PR DESCRIPTION
to allow distinguishing this case (prerequisite for #992)

This implicitly assumes `plyr::id` doesn't ever return 0. Tests in `plyr` test that sequences created by `id` start at 1, so we're probably safe here.

All tests pass, but I'm not sure if this has any other implications I'm not aware of.