### PR TITLE
has_groups()

### DIFF
--- a/R/utilities-layer.r
+++ b/R/utilities-layer.r
@@ -1,3 +1,5 @@
+# This needs to be less than 1, to distinguish it from "regular" return values
+# of plyr::id() used by add_group()
 NO_GROUP <- -1L
 
 # Ensure that the data frame contains a grouping variable.
@@ -10,6 +12,7 @@ NO_GROUP <- -1L
 # @param data.frame
 # @value data.frame with group variable
 # @keyword internal
+# @seealso has_groups
 add_group <- function(data) {
   if (empty(data)) return(data)
 
@@ -33,4 +36,13 @@ order_groups <- function(data) {
   if (is.null(data$order)) return(data)
 
   data[order(data$order), ]
+}
+
+# Is a grouping available?
+has_groups <- function(data) {
+  # If no group aesthetic is specified, all values of the group column equal to
+  # NO_GROUP. On the other hand, if a group aesthetic is specified, all values
+  # are different from NO_GROUP (since they are a result of plyr::id()). NA is
+  # returned for 0-row data frames.
+  data$group[1L] != NO_GROUP
 }

--- a/R/utilities-layer.r
+++ b/R/utilities-layer.r
@@ -39,6 +39,8 @@ order_groups <- function(data) {
 }
 
 # Is a grouping available?
+# (Will return TRUE if an explicit group or a discrete variable with only one
+# level existed when add_group() was called.)
 has_groups <- function(data) {
   # If no group aesthetic is specified, all values of the group column equal to
   # NO_GROUP. On the other hand, if a group aesthetic is specified, all values

--- a/tests/testthat/test-utilities.r
+++ b/tests/testthat/test-utilities.r
@@ -20,3 +20,10 @@ test_that("finite.cases.data.frame", {
   expect_identical(finite.cases(data.frame(x=Inf)),                   FALSE)
   expect_identical(finite.cases(data.frame(x=c(4,5),  y=c(-Inf,12))), c(FALSE, TRUE))
 })
+
+test_that("add_group", {
+  data <- data.frame(f=letters[7:9], x=1:3, y=4:6, group=c(1, -1, 1))
+  expect_true(has_groups(add_group(data[2:4])))  # explicit group column
+  expect_true(has_groups(add_group(data[1:3])))  # discrete column
+  expect_false(has_groups(add_group(data[2:3]))) # no group or discrete column
+})


### PR DESCRIPTION
Convenience function to encapsulate the check if the data are grouped. With test.

It still only checks only the first element of the group column, a comment explains why this works.

For #992.

(Sorry for being such a pain, but I really hate to check a vector if checking a value is enough.)