### PR TITLE
add reference to paper introducing violin plots

### DIFF
--- a/R/geom-violin.r
+++ b/R/geom-violin.r
@@ -9,6 +9,8 @@
 #' @param geom,stat Use to override the default connection between
 #'   \code{geom_violin} and \code{stat_ydensity}.
 #' @export
+#' @references Hintze, J. L., Nelson, R. D. (1998) Violin Plots: A Box
+#' Plot-Density Trace Synergism. The American Statistician 52, 181-184.
 #' @examples
 #' p <- ggplot(mtcars, aes(factor(cyl), mpg))
 #' p + geom_violin()

--- a/man/geom_violin.Rd
+++ b/man/geom_violin.Rd
@@ -130,6 +130,10 @@ ggplot(movies, aes(year, budget)) +
 }
 }
 }
+\references{
+Hintze, J. L., Nelson, R. D. (1998) Violin Plots: A Box
+Plot-Density Trace Synergism. The American Statistician 52, 181-184.
+}
 \seealso{
 \code{\link{geom_violin}} for examples, and \code{\link{stat_density}}
   for examples with data along the x axis.


### PR DESCRIPTION
Since violin plots are not known in every field of data analysis yet, it could be helpful to include a paper introducing the concept.

Hintze et al. seems to be the first and only paper on this matter: http://amstat.tandfonline.com/doi/abs/10.1080/00031305.1998.10480559