### PR TITLE
Tweaks for PANEL

### DIFF
--- a/R/facet-locate.r
+++ b/R/facet-locate.r
@@ -1,3 +1,7 @@
+# A "special" value, currently not used but could be used to determine
+# if faceting is active
+NO_PANEL <- -1L
+
 # Take single layer of data and combine it with panel information to split
 # data into different panels. Adds in extra data for missing facetting
 # levels and for margins.
@@ -37,7 +41,7 @@ locate_grid <- function(data, panels, rows = NULL, cols = NULL, margins = FALSE)
   # Add PANEL variable
   if (nrow(facet_vals) == 0) {
     # Special case of no facetting
-    data$PANEL <- 1
+    data$PANEL <- NO_PANEL
   } else {
     facet_vals[] <- lapply(facet_vals[], as.factor)
     facet_vals[] <- lapply(facet_vals[], addNA, ifany = TRUE)

--- a/R/utilities-layer.r
+++ b/R/utilities-layer.r
@@ -18,7 +18,7 @@ add_group <- function(data) {
 
   if (is.null(data$group)) {
     disc <- vapply(data, is.discrete, logical(1))
-    disc[names(disc) == "label"] <- FALSE
+    disc[names(disc) %in% c("label", "PANEL")] <- FALSE
 
     if (any(disc)) {
       data$group <- plyr::id(data[disc], drop = TRUE)


### PR DESCRIPTION
- `PANEL` is not taken into account for computing grouping when no `group` aesthetic is set
    - required for #992
    - otherwise, no warning can be given for the following example: `ggplot(expand.grid(x=1:10, y=1:10), aes(x, y)) + geom_boxplot() + facet_wrap(~y)`
- extract constant `NO_PANEL`, set it to -1
    - just like `NO_GROUP`

All tests pass locally.