### PR TITLE
fixed typo in error text of geom-path-.r: add "s" to "consist"

### DIFF
--- a/R/geom-path-.r
+++ b/R/geom-path-.r
@@ -114,7 +114,7 @@ GeomPath <- ggproto("GeomPath", Geom,
                   linejoin = "round", linemitre = 1, ..., na.rm = FALSE)
   {
     if (!anyDuplicated(data$group)) {
-      message("geom_path: Each group consist of only one observation. Do you need to adjust the group aesthetic?")
+      message("geom_path: Each group consists of only one observation. Do you need to adjust the group aesthetic?")
     }
 
     keep <- function(x) {


### PR DESCRIPTION
Info shown below is from file ```geom-path-.r```, line 117

**Original error text:** geom_path: Each group consist of only one observation. Do you need to adjust the group aesthetic?
**Updated error text:** geom_path: Each group consist**s** of only one observation. Do you need to adjust the group aesthetic?