### PR TITLE
Make some ggproto objects immutable. Closes #1237

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,6 +52,7 @@ Collate:
     'utilities.r'
     'aes.r'
     'legend-draw.r'
+    'immutable.r'
     'geom-.r'
     'annotation-custom.r'
     'annotation-logticks.r'

--- a/R/coord-.r
+++ b/R/coord-.r
@@ -32,7 +32,7 @@
 #' @format NULL
 #' @usage NULL
 #' @export
-Coord <- ggproto("Coord",
+Coord <- ggproto("Coord", Immutable,
 
   aspect = function(ranges) NULL,
 

--- a/R/geom-.r
+++ b/R/geom-.r
@@ -1,4 +1,4 @@
-#' @include legend-draw.r
+#' @include legend-draw.r immutable.r
 NULL
 
 #' @section Geoms:
@@ -51,7 +51,7 @@ NULL
 #' @format NULL
 #' @usage NULL
 #' @export
-Geom <- ggproto("Geom",
+Geom <- ggproto("Geom", Immutable,
   required_aes = character(),
   non_missing_aes = character(),
 

--- a/R/immutable.r
+++ b/R/immutable.r
@@ -1,0 +1,7 @@
+# Objects that inherit from this one can't be modified.
+Immutable <- ggproto("Immutable", NULL)
+
+#' @export
+`$<-.Immutable` <- function(x, i, value) {
+  stop("This object is immutable")
+}

--- a/R/layer.r
+++ b/R/layer.r
@@ -76,7 +76,7 @@ layer <- function(geom = NULL, stat = NULL,
   )
 }
 
-Layer <- ggproto("Layer", NULL,
+Layer <- ggproto("Layer", Immutable,
   geom = NULL,
   geom_params = NULL,
   stat = NULL,

--- a/R/position-.r
+++ b/R/position-.r
@@ -45,7 +45,7 @@
 #' @format NULL
 #' @usage NULL
 #' @export
-Position <- ggproto("Position",
+Position <- ggproto("Position", Immutable,
   required_aes = character(),
 
   setup_params = function(self, data) {

--- a/R/stat-.r
+++ b/R/stat-.r
@@ -46,7 +46,7 @@
 #' @format NULL
 #' @usage NULL
 #' @export
-Stat <- ggproto("Stat",
+Stat <- ggproto("Stat", Immutable,
   # Should the values produced by the statistic also be transformed
   # in the second pass when recently added statistics are trained to
   # the scales


### PR DESCRIPTION
This makes some ggproto objects in ggplot2 immutable. The exceptions are `Range`, `Scale` and `ScalesList`, because these need to be mutable for ggplot2 to work.

In this implementation, the objects inherit from an `Immutable` ggproto object. It might be slightly more efficient to simply add an `"Immutable"` class attribute to each of the objects (as in `Geom <- ggproto(c("Geom", "Immutable"), ...), but that might be slightly confusing since the S3 "superclasses" would differ from the ggproto superclasses.