### PR TITLE
add recordGraphics() to print.ggplot() 

### DIFF
--- a/R/plot.r
+++ b/R/plot.r
@@ -139,6 +139,11 @@ print.ggplot <- function(x, newpage = is.null(vp), vp = NULL, ...) {
   set_last_plot(x)
   if (newpage) grid.newpage()
 
+  # Record dependency on 'ggplot2' on the display list
+  # (AFTER grid.newpage())
+  recordGraphics(library("ggplot2", quietly=TRUE), 
+                 list(), getNamespace("ggplot2"))
+
   data <- ggplot_build(x)
 
   gtable <- ggplot_gtable(data)


### PR DESCRIPTION
to record library("ggplot2") on the graphics engine display list (for replaying recordPlot() in a different session without having to manually reload ggplot2)