### PR TITLE
Fix formatting of packageStartupMessage

### DIFF
--- a/R/zzz.r
+++ b/R/zzz.r
@@ -11,5 +11,5 @@
   )
 
   tip <- sample(tips, 1)
-  packageStartupMessage(strwrap(tip))
+  packageStartupMessage(strwrap(tip, prefix=" "))
 }


### PR DESCRIPTION
By default, `strwrap` destroys whitespace and removes spacing between words in output.

Before this fix:

```r
> packageStartupMessage(strwrap("Find out what's changed in ggplot2 at http://github.com/hadley/ggplot2/releases."))
Find out what's changed in ggplot2 athttp://github.com/hadley/ggplot2/releases.
```

after:

```r
> packageStartupMessage(strwrap("Find out what's changed in ggplot2 at http://github.com/hadley/ggplot2/releases.", prefix = " "))
 Find out what's changed in ggplot2 at http://github.com/hadley/ggplot2/releases.
```