### PR TITLE
Added xlim and ylim arguments to borders()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,9 @@ ggplot2 1.0.0
 
 NEW FEATURES
 
+* `borders()` now accepts xlim and ylim arguments for specifying the geographical 
+  region of interest (@markpayneatwork, #1392)
+
 * New coordinate system for small scale maps. `coord_quickmap()` computes and
   sets the correct aspect ratio between one degree of latitude and one degree
   of longitude at the centre of the plotted region. It does not perform full

--- a/NEWS
+++ b/NEWS
@@ -12,9 +12,6 @@ ggplot2 1.0.0
 
 NEW FEATURES
 
-* `borders()` now accepts xlim and ylim arguments for specifying the geographical 
-  region of interest (@markpayneatwork, #1392)
-
 * New coordinate system for small scale maps. `coord_quickmap()` computes and
   sets the correct aspect ratio between one degree of latitude and one degree
   of longitude at the centre of the plotted region. It does not perform full

--- a/NEWS.md
+++ b/NEWS.md
@@ -331,6 +331,9 @@ version of ggplot.
 
 ## Bug fixes and minor improvements
 
+* `borders()` now accepts xlim and ylim arguments for specifying the geographical 
+  region of interest (@markpayneatwork, #1392)
+
 * All partially matched arguments and `$` have been been replaced with 
   full matches (@jimhester, #1134).
 

--- a/R/fortify-map.r
+++ b/R/fortify-map.r
@@ -74,6 +74,7 @@ map_data <- function(map, region = ".", exact = FALSE, ...) {
 #' @param regions map region
 #' @param fill fill colour
 #' @param colour border colour
+#' @param "xlim, ylim" map xlim and ylim,, see \code{\link[maps]{map}} for details
 #' @param ... other arguments passed onto \code{\link{geom_polygon}}
 #' @export
 #' @examples
@@ -92,10 +93,17 @@ map_data <- function(map, region = ".", exact = FALSE, ...) {
 #'   borders("state") +
 #'   geom_point(aes(size = pop)) +
 #'   scale_size_area()
-#'
+#' 
+#' #Same map, with geographical context
+#' data(us.cities)
+#' capitals <- subset(us.cities, capital == 2)
+#' ggplot(capitals,aes(long,lat)) +
+#'   borders("world",xlim=c(-130,-60),ylim=c(20,50))+
+#'   geom_point(aes(size = pop)) +
+#'   scale_size_area()+coord_quickmap(xlim=c(-130,-60),ylim=c(20,50))
 #' }
-borders <- function(database = "world", regions = ".", fill = NA, colour = "grey50", ...) {
-  df <- map_data(database, regions)
+borders <- function(database = "world", regions = ".", fill = NA, colour = "grey50", xlim=NULL,ylim=NULL,...) {
+  df <- map_data(database, regions,xlim=xlim,ylim=ylim)
   geom_polygon(aes_(~long, ~lat, group = ~group), data = df,
     fill = fill, colour = colour, ..., inherit.aes = FALSE)
 }

--- a/R/fortify-map.r
+++ b/R/fortify-map.r
@@ -74,7 +74,7 @@ map_data <- function(map, region = ".", exact = FALSE, ...) {
 #' @param regions map region
 #' @param fill fill colour
 #' @param colour border colour
-#' @param "xlim, ylim" map xlim and ylim,, see \code{\link[maps]{map}} for details
+#' @param xlim,ylim latitudinal and logitudinal range for extracting map polygons, see \code{\link[maps]{map}} for details
 #' @param ... other arguments passed onto \code{\link{geom_polygon}}
 #' @export
 #' @examples
@@ -97,13 +97,13 @@ map_data <- function(map, region = ".", exact = FALSE, ...) {
 #' #Same map, with geographical context
 #' data(us.cities)
 #' capitals <- subset(us.cities, capital == 2)
-#' ggplot(capitals,aes(long,lat)) +
-#'   borders("world",xlim=c(-130,-60),ylim=c(20,50))+
+#' ggplot(capitals, aes(long, lat)) +
+#'   borders("world", xlim = c(-130, -60), ylim = c(20, 50)) +
 #'   geom_point(aes(size = pop)) +
-#'   scale_size_area()+coord_quickmap(xlim=c(-130,-60),ylim=c(20,50))
+#'   scale_size_area() + coord_quickmap(xlim = c(-130, -60), ylim = c(20, 50))
 #' }
 borders <- function(database = "world", regions = ".", fill = NA, colour = "grey50", xlim=NULL,ylim=NULL,...) {
-  df <- map_data(database, regions,xlim=xlim,ylim=ylim)
+  df <- map_data(database, regions, xlim = xlim, ylim = ylim)
   geom_polygon(aes_(~long, ~lat, group = ~group), data = df,
     fill = fill, colour = colour, ..., inherit.aes = FALSE)
 }


### PR DESCRIPTION
The borders() function is extremely handy if you are working with geographical data but the specification of the geographical region-of-interest is limited to defining regions via text strings i.e. via the regions="" argument. However, both the maps::map() function and ggplot2::map_data() accept geographic region specification using xlim and ylim arguments. This modification extemds that functionality to borders()