### PR TITLE
Fixed 'aes/aes_string' error message

### DIFF
--- a/R/plot.r
+++ b/R/plot.r
@@ -90,7 +90,7 @@ ggplot.default <- function(data = NULL, mapping = aes(), ...,
 ggplot.data.frame <- function(data, mapping = aes(), ...,
                               environment = parent.frame()) {
   if (!missing(mapping) && !inherits(mapping, "uneval")) {
-    stop("Mapping should be created with aes or aes_string")
+    stop("Mapping should be created with aes_()")
   }
 
   p <- structure(list(


### PR DESCRIPTION
This is a fix to the error message contained in the issue tracker.