### PR TITLE
Fix statdensity2d

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 2.0.0.9000
 
+## Bug fixes and minor improvements
+
+* `stat-density-2d()` no longer ignores the `h` parameter.
 # ggplot2 2.0.0
 
 ## Major changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 ## Bug fixes and minor improvements
 
 * `stat-density-2d()` no longer ignores the `h` parameter.
+
+* `stat-density-2d()` now accepts `bins` and `binwidth` parameters
+  to control the number of contour levels (#1448, @has2k1).
+
 # ggplot2 2.0.0
 
 ## Major changes

--- a/R/stat-density-2d.r
+++ b/R/stat-density-2d.r
@@ -44,7 +44,8 @@ StatDensity2d <- ggproto("StatDensity2d", Stat,
   required_aes = c("x", "y"),
 
   compute_group = function(data, scales, na.rm = FALSE, h = NULL,
-                           contour = TRUE, n = 100) {
+                           contour = TRUE, n = 100, bins = NULL,
+                           binwidth = NULL) {
     if (is.null(h)) {
       h <- c(MASS::bandwidth.nrd(data$x), MASS::bandwidth.nrd(data$y))
     }
@@ -57,7 +58,7 @@ StatDensity2d <- ggproto("StatDensity2d", Stat,
     df$group <- data$group[1]
 
     if (contour) {
-      StatContour$compute_panel(df, scales)
+      StatContour$compute_panel(df, scales, bins, binwidth)
     } else {
       names(df) <- c("x", "y", "density", "group")
       df$level <- 1

--- a/R/stat-density-2d.r
+++ b/R/stat-density-2d.r
@@ -23,6 +23,7 @@ stat_density_2d <- function(mapping = NULL, data = NULL, geom = "density_2d",
       na.rm = na.rm,
       contour = contour,
       n = n,
+      h = h,
       ...
     )
   )


### PR DESCRIPTION
Resolves

-  Minor slip up, user supplied h is ignored.
-  #1448, This was a regression due to the `...` refactoring.

I think more refactoring is needed to lift all the `stat$compute_group` parameters into the user API `stat()` function.