### PR TITLE
Check for non-zero length before calling list2env()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: ggplot2
-Version: 2.0.0.9000
+Version: 2.0.0.9001
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@rstudio.com", c("aut", "cre")),
     person("Winston", "Chang", , "winston@rstudio.com", "aut"),
@@ -14,7 +14,7 @@ Description: An implementation of the grammar of graphics in R. It combines the
     data to aesthetic attributes. See http://ggplot2.org for more information,
     documentation and examples.
 Depends:
-    R (>= 2.14)
+    R (>= 3.1)
 Imports:
     digest,
     grid,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## Bug fixes and minor improvements
 
+* Fixed a compatibility issue with `ggproto` and R versions prior to 3.1.2.
+  (#1444)
+
 * `stat-density-2d()` no longer ignores the `h` parameter.
 
 * `stat-density-2d()` now accepts `bins` and `binwidth` parameters

--- a/R/ggproto.r
+++ b/R/ggproto.r
@@ -36,7 +36,12 @@ ggproto <- function(`_class` = NULL, `_inherit` = NULL, ...) {
   if (length(members) != sum(nzchar(names(members)))) {
     stop("All members of a ggproto object must be named.")
   }
-  list2env(members, envir = e)
+
+  # R <3.1.2 will error when list2env() is given an empty list, so we need to
+  # check length. https://github.com/hadley/ggplot2/issues/1444
+  if (length(members) > 0) {
+    list2env(members, envir = e)
+  }
 
   if (!is.null(`_inherit`)) {
     if (!is.ggproto(`_inherit`)) {


### PR DESCRIPTION
This fixes #1444. I'd suggest making a release after merging, since this a blocker for many people.