### PR TITLE
Remove superfluous comma in function arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Bug fixes and minor improvements
 
+* Removed a superfluous comma in `theme-defaults.r` code (@jschoeley)
+
 * Fixed a compatibility issue with `ggproto` and R versions prior to 3.1.2.
   (#1444)
 

--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -86,7 +86,7 @@ theme_grey <- function(base_size = 11, base_family = "") {
                          ),
     axis.title.y =       element_text(
                            angle = 90,
-                           margin = margin(r = 0.8 * half_line, l = 0.8 * half_line / 2),
+                           margin = margin(r = 0.8 * half_line, l = 0.8 * half_line / 2)
                          ),
 
     legend.background =  element_rect(colour = NA),


### PR DESCRIPTION
The `element_text` function is called with a comma after its last argument. While this does not produce a bug, it is an irregularity better to be fixed.