### PR TITLE
Generalize position_jitterdodge to all possible dodge positions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## Bug fixes and minor improvements
 
+* `position_jitterdodge()` now works on all possible dodge aesthetics, 
+ e.g. `color`, `linetype` etc. instead of only based on `fill` (@bleutner)
+
 * Removed a superfluous comma in `theme-defaults.r` code (@jschoeley)
 
 * Fixed a compatibility issue with `ggproto` and R versions prior to 3.1.2.

--- a/R/position-jitterdodge.R
+++ b/R/position-jitterdodge.R
@@ -41,8 +41,9 @@ PositionJitterdodge <- ggproto("PositionJitterdodge", Position,
     width <- self$jitter.width %||% resolution(data$x, zero = FALSE) * 0.4
     # Adjust the x transformation based on the number of 'dodge' variables
     dodgecols <- intersect(c("fill", "colour", "linetype", "shape", "size", "alpha"), colnames(data))  
-    if (length(dodgecols) == 0) stop("`position_jitterdodge()` requires ",
-                "at least one aesthetic to dodge by", call. = FALSE)
+    if (length(dodgecols) == 0) {
+      stop("`position_jitterdodge()` requires at least one aesthetic to dodge by", call. = FALSE)
+    }
     ndodge    <- lapply(data[dodgecols], levels)  # returns NULL for numeric, i.e. non-dodge layers
     ndodge    <- length(unique(unlist(ndodge)))
     

--- a/R/position-jitterdodge.R
+++ b/R/position-jitterdodge.R
@@ -35,7 +35,7 @@ PositionJitterdodge <- ggproto("PositionJitterdodge", Position,
   jitter.height = NULL,
   dodge.width = NULL,
 
-  required_aes = c("x", "y", "fill"),
+  required_aes = c("x", "y"),
 
   setup_params = function(self, data) {
     width <- self$jitter.width %||% resolution(data$x, zero = FALSE) * 0.4

--- a/R/position-jitterdodge.R
+++ b/R/position-jitterdodge.R
@@ -38,12 +38,13 @@ PositionJitterdodge <- ggproto("PositionJitterdodge", Position,
   required_aes = c("x", "y"),
 
   setup_params = function(self, data) {
-      width <- self$jitter.width %||% resolution(data$x, zero = FALSE) * 0.4
-      # Adjust the x transformation based on the number of 'dodge' variables
-      dodgecols <- intersect(c("fill", "colour", "linetype", "shape", "size", "alpha"), colnames(data))  
-      if (length(dodgecols) == 0) stop("position_jitterdodge requires at least aesthetic to dodge by", call. = FALSE)
-      ndodge    <- lapply(data[ , dodgecols, drop = FALSE], levels)  # returns NULL for numeric, i.e. non-dodge layers
-      ndodge    <- length(unique(unlist(ndodge)))
+    width <- self$jitter.width %||% resolution(data$x, zero = FALSE) * 0.4
+    # Adjust the x transformation based on the number of 'dodge' variables
+    dodgecols <- intersect(c("fill", "colour", "linetype", "shape", "size", "alpha"), colnames(data))  
+    if (length(dodgecols) == 0) stop("`position_jitterdodge()` requires ",
+                "at least one aesthetic to dodge by", call. = FALSE)
+    ndodge    <- lapply(data[dodgecols], levels)  # returns NULL for numeric, i.e. non-dodge layers
+    ndodge    <- length(unique(unlist(ndodge)))
     
     list(
       dodge.width = self$dodge.width,

--- a/R/position-jitterdodge.R
+++ b/R/position-jitterdodge.R
@@ -38,14 +38,17 @@ PositionJitterdodge <- ggproto("PositionJitterdodge", Position,
   required_aes = c("x", "y"),
 
   setup_params = function(self, data) {
-    width <- self$jitter.width %||% resolution(data$x, zero = FALSE) * 0.4
-    # Adjust the x transformation based on the number of 'fill' variables
-    nfill <- length(levels(data$fill))
-
+      width <- self$jitter.width %||% resolution(data$x, zero = FALSE) * 0.4
+      # Adjust the x transformation based on the number of 'dodge' variables
+      dodgecols <- intersect(c("fill", "colour", "linetype", "shape", "size", "alpha"), colnames(data))  
+      if (length(dodgecols) == 0) stop("position_jitterdodge requires at least aesthetic to dodge by", call. = FALSE)
+      ndodge    <- lapply(data[ , dodgecols, drop = FALSE], levels)  # returns NULL for numeric, i.e. non-dodge layers
+      ndodge    <- length(unique(unlist(ndodge)))
+    
     list(
       dodge.width = self$dodge.width,
       jitter.height = self$jitter.height,
-      jitter.width = width / (nfill + 2)
+      jitter.width = width / (ndodge + 2)
     )
   },
 


### PR DESCRIPTION
So far, `position_jitterdodge()` is limited to boxplots dodged by the `fill` aesthetic. 
This pull request generalizes the function to work properly on all posible dodge aesthetics:
* `fill`
* `colour`
* `linetype`
* `alpha`
* `size`
* `shape`

not that all of these readily make sense to me, but as long as it is supported by boxplot etc. I think it would be good to have this functionality. I for one was trying based on `colour` dodging, when I came upon this.

```{r}
library(ggplot2)
# Example data
data(diamonds)
dsub <- subset(diamonds, clarity %in% levels(clarity)[1:3] & color %in% levels(color)[1:2])   
dsub$test <- sample(c("a","b"), nrow(dsub), replace = TRUE) 

# Set-up ggplot
p <- ggplot(dsub) +
        geom_boxplot(outlier.colour = NA) +   
        geom_point(position = position_jitterdodge())

# So far we are limited to dodge by 'fill'
p %+% aes(x = cut, y = carat, fill = clarity) 

# Dodge by single aesthetic #####################
# Dodge by: colour
p %+% aes(x = cut, y = carat, colour = clarity)

# Dodge by: linetype          
p %+%  aes(x = cut, y = carat, linetype = clarity)

# Dodge by: alpha          
p %+%  aes(x = cut, y = carat, alpha = clarity)

# Dodge by: size          
p %+%  aes(x = cut, y = carat, size = clarity)

# Dodge by: shape          
p %+%  aes(x = cut, y = carat, shape = clarity)

# Dodge interactions ############################
# Dodge by: fill & colour , case fill == color    
p %+%  aes(x = cut, y = carat, fill = clarity, colour = clarity)

# Dodge by: fill & colour , case fill != color        
p %+% aes(x = cut, y = carat, fill = clarity, colour = color)

# Dodge by: fill & colour & linetype
p %+% aes(x = cut, y = carat, fill = clarity, linetype = color, color = test)

```
