### PR TITLE
Add access to bw argument of density

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 2.0.0.9000
 
+* Add access to `bw` argument of `density` in `stat_density`, which makes
+  it easy to get consistent smoothing between facets for example (@jiho)
+
 ## Bug fixes and minor improvements
 
 * Removed a superfluous comma in `theme-defaults.r` code (@jschoeley)

--- a/R/stat-density.r
+++ b/R/stat-density.r
@@ -1,4 +1,7 @@
-#' @param adjust see \code{\link{density}} for details
+#' @param bw the smoothing bandwidth to be used, see 
+#'   \code{\link{density}} for details
+#' @param adjust adjustment of the bandwidth, see
+#'   \code{\link{density}} for details
 #' @param kernel kernel used for density estimation, see
 #'   \code{\link{density}} for details
 #' @param trim This parameter only matters if you are displaying multiple
@@ -17,7 +20,7 @@
 #' @export
 #' @rdname geom_density
 stat_density <- function(mapping = NULL, data = NULL, geom = "area",
-                         position = "stack", adjust = 1, kernel = "gaussian",
+                         position = "stack", bw = "nrd0", adjust = 1, kernel = "gaussian",
                          trim = FALSE, na.rm = FALSE,
                          show.legend = NA, inherit.aes = TRUE, ...) {
 
@@ -30,6 +33,7 @@ stat_density <- function(mapping = NULL, data = NULL, geom = "area",
     show.legend = show.legend,
     inherit.aes = inherit.aes,
     params = list(
+      bw = bw,
       adjust = adjust,
       kernel = kernel,
       trim = trim,
@@ -47,7 +51,7 @@ StatDensity <- ggproto("StatDensity", Stat,
   required_aes = "x",
   default_aes = aes(y = ..density.., fill = NA),
 
-  compute_group = function(data, scales, adjust = 1, kernel = "gaussian",
+  compute_group = function(data, scales, bw = "nrd0", adjust = 1, kernel = "gaussian",
                            trim = FALSE, na.rm = FALSE) {
     if (trim) {
       range <- range(data$x, na.rm = TRUE)
@@ -56,7 +60,7 @@ StatDensity <- ggproto("StatDensity", Stat,
     }
 
     compute_density(data$x, data$weight, from = range[1], to = range[2],
-      adjust = adjust, kernel = kernel)
+      bw = bw, adjust = adjust, kernel = kernel)
   }
 
 )

--- a/R/stat-ydensity.r
+++ b/R/stat-ydensity.r
@@ -18,7 +18,7 @@
 #' @export
 #' @rdname geom_violin
 stat_ydensity <- function(mapping = NULL, data = NULL, geom = "violin",
-                          position = "dodge", adjust = 1, kernel = "gaussian",
+                          position = "dodge", bw = "nrd0", adjust = 1, kernel = "gaussian",
                           trim = TRUE, scale = "area", na.rm = FALSE,
                           show.legend = NA, inherit.aes = TRUE, ...) {
   scale <- match.arg(scale, c("area", "count", "width"))
@@ -32,6 +32,7 @@ stat_ydensity <- function(mapping = NULL, data = NULL, geom = "violin",
     show.legend = show.legend,
     inherit.aes = inherit.aes,
     params = list(
+      bw = bw,
       adjust = adjust,
       kernel = kernel,
       trim = trim,
@@ -51,7 +52,7 @@ StatYdensity <- ggproto("StatYdensity", Stat,
   required_aes = c("x", "y"),
   non_missing_aes = "weight",
 
-  compute_group = function(data, scales, width = NULL, adjust = 1,
+  compute_group = function(data, scales, width = NULL, bw = "nrd0", adjust = 1,
                        kernel = "gaussian", trim = TRUE, na.rm = FALSE) {
     if (nrow(data) < 3) return(data.frame())
 
@@ -61,7 +62,7 @@ StatYdensity <- ggproto("StatYdensity", Stat,
       range <- scales$y$dimension()
     }
     dens <- compute_density(data$y, data$w, from = range[1], to = range[2],
-      adjust = adjust, kernel = kernel)
+      bw = bw, adjust = adjust, kernel = kernel)
 
     dens$y <- dens$x
     dens$x <- mean(range(data$x))
@@ -75,11 +76,11 @@ StatYdensity <- ggproto("StatYdensity", Stat,
     dens
   },
 
-  compute_panel = function(self, data, scales, width = NULL, adjust = 1,
+  compute_panel = function(self, data, scales, width = NULL, bw = "nrd0", adjust = 1,
                            kernel = "gaussian", trim = TRUE, na.rm = FALSE,
                            scale = "area") {
     data <- ggproto_parent(Stat, self)$compute_panel(
-      data, scales, width = width, adjust = adjust, kernel = kernel,
+      data, scales, width = width, bw = bw, adjust = adjust, kernel = kernel,
       trim = trim, na.rm = na.rm
     )
 

--- a/man/geom_density.Rd
+++ b/man/geom_density.Rd
@@ -10,8 +10,9 @@ geom_density(mapping = NULL, data = NULL, stat = "density",
   inherit.aes = TRUE, ...)
 
 stat_density(mapping = NULL, data = NULL, geom = "area",
-  position = "stack", adjust = 1, kernel = "gaussian", trim = FALSE,
-  na.rm = FALSE, show.legend = NA, inherit.aes = TRUE, ...)
+  position = "stack", bw = "nrd0", adjust = 1, kernel = "gaussian",
+  trim = FALSE, na.rm = FALSE, show.legend = NA, inherit.aes = TRUE,
+  ...)
 }
 \arguments{
 \item{mapping}{Set of aesthetic mappings created by \code{\link{aes}} or
@@ -52,7 +53,11 @@ the default plot specification, e.g. \code{\link{borders}}.}
 \item{geom, stat}{Use to override the default connection between
 \code{geom_density} and \code{stat_density}.}
 
-\item{adjust}{see \code{\link{density}} for details}
+\item{bw}{the smoothing bandwidth to be used, see 
+\code{\link{density}} for details}
+
+\item{adjust}{adjustment of the bandwidth, see
+\code{\link{density}} for details}
 
 \item{kernel}{kernel used for density estimation, see
 \code{\link{density}} for details}

--- a/man/geom_violin.Rd
+++ b/man/geom_violin.Rd
@@ -64,7 +64,8 @@ the default plot specification, e.g. \code{\link{borders}}.}
 \item{geom, stat}{Use to override the default connection between
 \code{geom_violin} and \code{stat_ydensity}.}
 
-\item{adjust}{see \code{\link{density}} for details}
+\item{adjust}{adjustment of the bandwidth, see
+\code{\link{density}} for details}
 
 \item{kernel}{kernel used for density estimation, see
 \code{\link{density}} for details}

--- a/man/geom_violin.Rd
+++ b/man/geom_violin.Rd
@@ -11,9 +11,9 @@ geom_violin(mapping = NULL, data = NULL, stat = "ydensity",
   ...)
 
 stat_ydensity(mapping = NULL, data = NULL, geom = "violin",
-  position = "dodge", adjust = 1, kernel = "gaussian", trim = TRUE,
-  scale = "area", na.rm = FALSE, show.legend = NA, inherit.aes = TRUE,
-  ...)
+  position = "dodge", bw = "nrd0", adjust = 1, kernel = "gaussian",
+  trim = TRUE, scale = "area", na.rm = FALSE, show.legend = NA,
+  inherit.aes = TRUE, ...)
 }
 \arguments{
 \item{mapping}{Set of aesthetic mappings created by \code{\link{aes}} or
@@ -63,6 +63,9 @@ the default plot specification, e.g. \code{\link{borders}}.}
 
 \item{geom, stat}{Use to override the default connection between
 \code{geom_violin} and \code{stat_ydensity}.}
+
+\item{bw}{the smoothing bandwidth to be used, see 
+\code{\link{density}} for details}
 
 \item{adjust}{adjustment of the bandwidth, see
 \code{\link{density}} for details}


### PR DESCRIPTION
It is sometimes useful to set a fixed bandwidth, to make it easier to compare between facets for example. Here is some code to demonstrate a use case

```r
d <- data.frame(
  a=rep(c("a", "b"), each=100),
  x=c(rnorm(50, 0, 0.2), rnorm(50, 0.5, 0.2), rnorm(100, 0, 2))
)
ggplot(d) + geom_density(aes(x=x)) + facet_wrap(~a)
ggplot(d) + geom_density(aes(x=x), bw=0.3) + facet_wrap(~a)

ggplot(d) + geom_density(aes(x=x)) + facet_wrap(~a, scales="free_x") 
ggplot(d) + geom_density(aes(x=x), bw=0.3) + facet_wrap(~a, scales="free_x")
```

I've been wanting this a few times already. I resorted to computing the densities manually and then plotting. Today I decided to be less lazy ;-)