### PR TITLE
Still label legends and facets in theme_void

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 2.0.0.9000
 
+* `theme_void()` was completely void of text but facets and legends still
+  needed labels. They are now visible (@jiho).
+
 * Multipanel empty data is correctly plotted, rather than throwing an unhelpful 
   error (#1445).
 

--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -269,8 +269,20 @@ theme_void <- function(base_size = 12, base_family = "") {
     # Use only inherited elements and make everything blank
     line =               element_blank(),
     rect =               element_blank(),
-    text =               element_blank(),
+    text =               element_text(
+                            family = base_family, face = "plain",
+                            colour = "black", size = base_size,
+                            lineheight = 0.9, hjust = 0.5, vjust = 0.5, angle = 0,
+                            margin = margin(), debug = FALSE
+                         ),
     plot.margin =        unit(c(0, 0, 0, 0), "lines"),
+    axis.text.x =        element_blank(),
+    axis.text.y =        element_blank(),
+    axis.title.x =       element_blank(),
+    axis.title.y =       element_blank(),
+    legend.text =        element_text(size = rel(0.8)),
+    legend.title =       element_blank(),
+    strip.text =         element_text(size = rel(0.8)),
 
     complete = TRUE
   )


### PR DESCRIPTION
While theme_void is meant for drawings or plots in which the coordinates
are self describing (like maps for examples), subplots and aesthetics
still need to be described. The legend itself can be removed with
`guide = none` in the scale functions.