### PR TITLE
Examples for plotmath expressions in `annotate`

### DIFF
--- a/R/annotation.r
+++ b/R/annotation.r
@@ -29,6 +29,11 @@
 #'   colour = "red", size = 1.5)
 #'
 #' p + annotate("text", x = 2:3, y = 20:21, label = c("my label", "label 2"))
+#'
+#' p + annotate("text", x = 4, y = 25, label = "italic(R) ^ 2 == 0.75",
+#'   parse = TRUE)
+#' p + annotate("text", x = 4, y = 25,
+#'   label = "paste(italic(R) ^ 2, \" = .75\")", parse = TRUE)
 annotate <- function(geom, x = NULL, y = NULL, xmin = NULL, xmax = NULL,
                      ymin = NULL, ymax = NULL, xend = NULL, yend = NULL, ...,
                      na.rm = FALSE) {

--- a/man/annotate.Rd
+++ b/man/annotate.Rd
@@ -47,5 +47,10 @@ p + annotate("pointrange", x = 3.5, y = 20, ymin = 12, ymax = 28,
   colour = "red", size = 1.5)
 
 p + annotate("text", x = 2:3, y = 20:21, label = c("my label", "label 2"))
+
+p + annotate("text", x = 4, y = 25, label = "italic(R) ^ 2 == 0.75",
+  parse = TRUE)
+p + annotate("text", x = 4, y = 25,
+  label = "paste(italic(R) ^ 2, \\" = .75\\")", parse = TRUE)
 }
 


### PR DESCRIPTION
Adding two examples to the documentation of `annotate` about how to pass plotmath expressions.

1. simple plotmath expression
1. mixing plotmath syntax and plain text using `paste`

See #1548.