### PR TITLE
adding pad param to stat_count

### DIFF
--- a/R/stat-count.r
+++ b/R/stat-count.r
@@ -18,6 +18,7 @@ stat_count <- function(mapping = NULL, data = NULL,
                        geom = "bar", position = "stack",
                        ...,
                        width = NULL,
+                       pad = FALSE,
                        na.rm = FALSE,
                        show.legend = NA,
                        inherit.aes = TRUE) {
@@ -30,6 +31,7 @@ stat_count <- function(mapping = NULL, data = NULL,
     show.legend = show.legend,
     inherit.aes = inherit.aes,
     params = list(
+      pad = pad,
       na.rm = na.rm,
       width = width,
       ...
@@ -50,10 +52,14 @@ StatCount <- ggproto("StatCount", Stat,
     if (!is.null(data$y) || !is.null(params$y)) {
       stop("stat_count() must not be used with a y aesthetic.", call. = FALSE)
     }
+    if (!is.null(params$drop)) {
+      warning("`drop` is deprecated. Please use `pad` instead.", call. = FALSE)
+      params$drop <- NULL
+    }
     params
   },
 
-  compute_group = function(self, data, scales, width = NULL) {
+  compute_group = function(self, data, scales, width = NULL, pad = FALSE) {
     x <- data$x
     weight <- data$weight %||% rep(1, length(x))
     width <- width %||% (resolution(x) * 0.9)


### PR DESCRIPTION
can't compile ggplot2 book or run stat_count examples with freqpoly
```r
 ggplot(diamonds, aes(color, colour = cut)) + 
    geom_freqpoly(aes(group = cut), stat="count")
#Error: Unknown parameters: pad
```

Code added from stat_bin mostly. Unsure how it is incorporated into the calculations in lines 56-71 like in stat_bin. Tested from my branch and is working. 