### PR TITLE
guide_colourbar now respects show.legend

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 * `x` and `y` scales are now symmetric regarding the list of
   aesthetics they accept: `xmin_final`, `xmax_final`, `xlower`,
   `xmiddle` and `xupper` are now valid `x` aesthetics.
+  
+* `guide_colourbar` now respects the layer parameter `show.legend`.
+  When `show.legend` is set to `FALSE` a colourbar will not be
+  shown. (@has2k1)
 
 # ggplot2 2.1.0
 

--- a/R/guide-colorbar.r
+++ b/R/guide-colorbar.r
@@ -211,7 +211,26 @@ guide_merge.colorbar <- function(guide, new_guide) {
 
 # this guide is not geom-based.
 #' @export
-guide_geom.colorbar <- function(guide, ...) {
+guide_geom.colorbar <- function(guide, layers, default_mapping) {
+  # Layers that use this guide
+  guide_layers <- plyr::llply(layers, function(layer) {
+    all <- names(c(layer$mapping, if (layer$inherit.aes) default_mapping, layer$stat$default_aes))
+    geom <- c(layer$geom$required_aes, names(layer$geom$default_aes))
+    matched <- intersect(intersect(all, geom), names(guide$key))
+    matched <- setdiff(matched, names(layer$geom_params))
+    matched <- setdiff(matched, names(layer$aes_params))
+
+    if (length(matched) && ((is.na(layer$show.legend) || layer$show.legend))){
+      layer
+    } else {
+      # This layer does not use this guide
+      NULL
+    }
+  })
+
+  # Remove this guide if no layer uses it
+  if (length(compact(guide_layers)) == 0) guide <- NULL
+
   guide
 }
 

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -8,3 +8,16 @@ test_that("colourbar trains without labels", {
   expect_equal(names(out$key), c("colour", ".value"))
 })
 
+
+test_that("colourbar respects show.legend", {
+  df = data.frame(x=c(1,2,3), y=c(1,2,3))
+  p <- ggplot(aes(x, y, fill=y), data=df) + geom_tile(show.legend=F)
+  theme <- theme_gray()
+  position <- theme$legend.position
+  out <- ggplot_build(p)
+  plot <- out$plot
+  box <- build_guides(plot$scales, plot$layers, plot$mapping,
+                      position, theme, plot$guides,
+                      plot$labels)
+  expect_true(class(box)[1] == "zeroGrob")
+})


### PR DESCRIPTION
Previously, a colourbar was always drawn whenever there was a
colour/fill mapping to a continuous variable.

Solution is to kill the guide if any has been created but if
no layer uses it.

*Addendum*
There are 3 places in the code where it is decided whether a legend will show up
or not. A better solution would be to fix that. At the moment, this (which added the 3rd)
is the least destructive.

fixes #1568