### PR TITLE
Show a list of shapes in scale_shape docs

### DIFF
--- a/R/scale-shape.r
+++ b/R/scale-shape.r
@@ -26,11 +26,11 @@
 #' d %+% dsmall
 #'
 #' # Show a list of available shapes
-#' df_shapes <- data.frame(shape = factor(0:24))
-#' ggplot(df_shapes, aes(shape=shape)) +
-#'   geom_point(aes(shape=shape, x=0, y=0), size=5, fill="red") +
-#'   facet_wrap(~shape) +
-#'   scale_shape_manual(values=df_shapes$shape, guide="none")
+#' df_shapes <- data.frame(shape = 0:24)
+#' ggplot(df_shapes, aes(shape = shape)) +
+#'   geom_point(aes(shape = shape, x = 0, y = 0), size = 5, fill = 'red') +
+#'   scale_shape_identity() +
+#'   facet_wrap(~shape) + theme_void()
 scale_shape <- function(..., solid = TRUE) {
   discrete_scale("shape", "shape_d", shape_pal(solid), ...)
 }

--- a/R/scale-shape.r
+++ b/R/scale-shape.r
@@ -26,11 +26,11 @@
 #' d %+% dsmall
 #'
 #' # Show a list of available shapes
-#' shapes <- 0:25
-#' df_shapes <- data.frame(shape = factor(shapes), x=(shapes %% 10), y=10 * floor(shapes / 10))
-#' ggplot(df_shapes, aes(shape=shape, x=x, y=y)) +
-#'   geom_point(size=5, fill='red') +
-#'   scale_shape_manual(values=shapes)
+#' df_shapes <- data.frame(shape = factor(0:24))
+#' ggplot(df_shapes, aes(shape=shape)) +
+#'   geom_point(aes(shape=shape, x=0, y=0), size=5, fill="red") +
+#'   facet_wrap(~shape) +
+#'   scale_shape_manual(values=df_shapes$shape, guide="none")
 scale_shape <- function(..., solid = TRUE) {
   discrete_scale("shape", "shape_d", shape_pal(solid), ...)
 }

--- a/R/scale-shape.r
+++ b/R/scale-shape.r
@@ -24,6 +24,13 @@
 #'
 #' # Or for short:
 #' d %+% dsmall
+#'
+#' # Show a list of available shapes
+#' shapes <- 0:25
+#' df_shapes <- data.frame(shape = factor(shapes), x=(shapes %% 10), y=10 * floor(shapes / 10))
+#' ggplot(df_shapes, aes(shape=shape, x=x, y=y)) +
+#'   geom_point(size=5, fill='red') +
+#'   scale_shape_manual(values=shapes)
 scale_shape <- function(..., solid = TRUE) {
   discrete_scale("shape", "shape_d", shape_pal(solid), ...)
 }

--- a/man/scale_shape.Rd
+++ b/man/scale_shape.Rd
@@ -36,5 +36,12 @@ ggplot(dsmall, aes(price, carat)) + geom_point(aes(shape = cut))
 
 # Or for short:
 d \%+\% dsmall
+
+# Show a list of available shapes
+shapes <- 0:25
+df_shapes <- data.frame(shape = factor(shapes), x=(shapes \%\% 10), y=10 * floor(shapes / 10))
+ggplot(df_shapes, aes(shape=shape, x=x, y=y)) +
+  geom_point(size=5, fill='red') +
+  scale_shape_manual(values=shapes)
 }
 

--- a/man/scale_shape.Rd
+++ b/man/scale_shape.Rd
@@ -38,10 +38,10 @@ ggplot(dsmall, aes(price, carat)) + geom_point(aes(shape = cut))
 d \%+\% dsmall
 
 # Show a list of available shapes
-shapes <- 0:25
-df_shapes <- data.frame(shape = factor(shapes), x=(shapes \%\% 10), y=10 * floor(shapes / 10))
-ggplot(df_shapes, aes(shape=shape, x=x, y=y)) +
-  geom_point(size=5, fill='red') +
-  scale_shape_manual(values=shapes)
+df_shapes <- data.frame(shape = factor(0:24))
+ggplot(df_shapes, aes(shape=shape)) +
+  geom_point(aes(shape=shape, x=0, y=0), size=5, fill="red") +
+  facet_wrap(~shape) +
+  scale_shape_manual(values=df_shapes$shape, guide="none")
 }
 

--- a/man/scale_shape.Rd
+++ b/man/scale_shape.Rd
@@ -38,10 +38,10 @@ ggplot(dsmall, aes(price, carat)) + geom_point(aes(shape = cut))
 d \%+\% dsmall
 
 # Show a list of available shapes
-df_shapes <- data.frame(shape = factor(0:24))
-ggplot(df_shapes, aes(shape=shape)) +
-  geom_point(aes(shape=shape, x=0, y=0), size=5, fill="red") +
-  facet_wrap(~shape) +
-  scale_shape_manual(values=df_shapes$shape, guide="none")
+df_shapes <- data.frame(shape = 0:24)
+ggplot(df_shapes, aes(shape = shape)) +
+  geom_point(aes(shape = shape, x = 0, y = 0), size = 5, fill = 'red') +
+  scale_shape_identity() +
+  facet_wrap(~shape) + theme_void()
 }
 


### PR DESCRIPTION
I often wind up hunting for the indices corresponding to different shapes, and it'd be nice if they were in the docs.