### PR TITLE
Let Stats and Geoms know about specification of aesthetics and faceting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,8 @@
 
 * `Stat`'s `setup_params()` method now takes a `spec` argument that
   contains information about the specification of aesthetics and
-  facetting. See `Stat`'s documentation. (@lionel-)
+  facetting. See `Stat`'s documentation. `Geom` gains a similar
+  `setup_params()` method. (@lionel-)
 
 # ggplot2 2.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,10 @@
 * Minor code formatting issues in examples and function parameters were
   fixed. (@hrbrmstr)
 
+* `Stat`'s `setup_params()` method now takes a `spec` argument that
+  contains information about the specification of aesthetics and
+  facetting. See `Stat`'s documentation. (@lionel-)
+
 # ggplot2 2.1.0
 
 ## New features

--- a/R/geom-.r
+++ b/R/geom-.r
@@ -13,11 +13,11 @@ NULL
 #' implement one or more of the following:
 #'
 #' Compared to \code{Stat} and \code{Position}, \code{Geom} is a little
-#' different because the execution of the setup and compute functions is
-#' split up. \code{setup_data} runs before position adjustments, and
-#' \code{draw_layer} is not run until render time,  much later. This
-#' means there is no \code{setup_params} because it's hard to communicate
-#' the changes.
+#' different because the execution of the setup and compute functions is split
+#' up. \code{setup_params} and \code{setup_data} run before position
+#' adjustments, and \code{draw_layer} is not run until render time, much
+#' later. This means there is no \code{setup_params} because it's hard to
+#' communicate the changes.
 #'
 #' \itemize{
 #'   \item Override either \code{draw_panel(self, data, panel_scales, coord)} or
@@ -98,6 +98,8 @@ Geom <- ggproto("Geom",
   draw_group = function(self, data, panel_scales, coord) {
     stop("Not implemented")
   },
+
+  setup_params = function(data, params, spec) params,
 
   setup_data = function(data, params) data,
 

--- a/R/layer.r
+++ b/R/layer.r
@@ -249,9 +249,14 @@ Layer <- ggproto("Layer", NULL,
     cunion(stat_data, data)
   },
 
-  compute_geom_1 = function(self, data) {
+  compute_geom_1 = function(self, data, plot) {
     if (empty(data)) return(data.frame())
-    data <- self$geom$setup_data(data, c(self$geom_params, self$aes_params))
+
+    spec <- spec(self, plot)
+    params <- c(self$geom_params, self$aes_params)
+
+    params <- self$geom$setup_params(data, params, spec)
+    data <- self$geom$setup_data(data, params)
 
     check_required_aesthetics(
       self$geom$required_aes,

--- a/R/layer.r
+++ b/R/layer.r
@@ -209,11 +209,13 @@ Layer <- ggproto("Layer", NULL,
     evaled
   },
 
-  compute_statistic = function(self, data, panel) {
+  compute_statistic = function(self, data, panel, plot) {
     if (empty(data))
       return(data.frame())
 
-    params <- self$stat$setup_params(data, self$stat_params)
+    spec <- spec(self, plot)
+
+    params <- self$stat$setup_params(data, self$stat_params, spec)
     data <- self$stat$setup_data(data, params)
     self$stat$compute_layer(data, params, panel)
   },
@@ -302,4 +304,31 @@ find_subclass <- function(super, class) {
   }
 
   obj
+}
+
+
+spec <- function(layer, plot) {
+  list(
+    facet_spec = facet_spec(plot$facet),
+    plot_mapping = plot$mapping,
+    layer_mapping = layer$mapping
+  )
+}
+
+facet_spec <- function(facet) {
+  UseMethod("facet_spec")
+}
+
+facet_spec.wrap <- function(facet) {
+  spec <- list(facets = facet$facets)
+  structure(spec, class = c("wrap", "spec"))
+}
+
+facet_spec.grid <- function(facet) {
+  spec <- list(rows = facet$rows, cols = facet$cols)
+  structure(spec, class = c("grid", "spec"))
+}
+
+facet_spec.null <- function(facet) {
+  NULL
 }

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -56,7 +56,7 @@ ggplot_build <- function(plot) {
   data <- map_position(panel, data, scale_x(), scale_y())
 
   # Apply and map statistics
-  data <- by_layer(function(l, d) l$compute_statistic(d, panel))
+  data <- by_layer(function(l, d) l$compute_statistic(d, panel, plot))
   data <- by_layer(function(l, d) l$map_statistic(d, plot))
 
   # Make sure missing (but required) aesthetics are added

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -63,7 +63,7 @@ ggplot_build <- function(plot) {
   scales_add_missing(plot, c("x", "y"), plot$plot_env)
 
   # Reparameterise geoms from (e.g.) y and width to ymin and ymax
-  data <- by_layer(function(l, d) l$compute_geom_1(d))
+  data <- by_layer(function(l, d) l$compute_geom_1(d, plot))
 
   # Apply position adjustments
   data <- by_layer(function(l, d) l$compute_position(d, panel))

--- a/R/stat-.r
+++ b/R/stat-.r
@@ -30,9 +30,13 @@
 #'     before the facets are trained, so they are global scales, not local
 #'     to the individual panels.\code{...} contains the parameters returned by
 #'     \code{setup_params()}.
-#'   \item \code{setup_params(data, params)}: called once for each layer.
+#'   \item \code{setup_params(data, params, spec)}: called once for each layer.
 #'      Used to setup defaults that need to complete dataset, and to inform
 #'      the user of important choices. Should return list of parameters.
+#'      The \code{spec} argument is a list containing information about the
+#'      facetting specification (slot \code{facet_spec}), the specification of
+#'      plot aesthetics (slot \code{plot_mapping}), and the specification of
+#'      the layer aesthetics (slot \code{layer_mapping}).
 #'   \item \code{setup_data(data, params)}: called once for each layer,
 #'      after \code{setp_params()}. Should return modified \code{data}.
 #'      Default methods removes all rows containing a missing value in
@@ -58,7 +62,7 @@ Stat <- ggproto("Stat",
 
   non_missing_aes = character(),
 
-  setup_params = function(data, params) {
+  setup_params = function(data, params, spec) {
     params
   },
 

--- a/R/stat-bin.r
+++ b/R/stat-bin.r
@@ -76,7 +76,7 @@ stat_bin <- function(mapping = NULL, data = NULL,
 #' @usage NULL
 #' @export
 StatBin <- ggproto("StatBin", Stat,
-  setup_params = function(data, params) {
+  setup_params = function(data, params, spec) {
     if (!is.null(data$y) || !is.null(params$y)) {
       stop("stat_bin() must not be used with a y aesthetic.", call. = FALSE)
     }

--- a/R/stat-bindot.r
+++ b/R/stat-bindot.r
@@ -7,7 +7,7 @@ StatBindot <- ggproto("StatBindot", Stat,
   non_missing_aes = "weight",
   default_aes = aes(y = ..count..),
 
-  setup_params = function(data, params) {
+  setup_params = function(data, params, spec) {
     if (is.null(params$binwidth)) {
       message("`stat_bindot()` using `bins = 30`. Pick better value with `binwidth`.")
     }

--- a/R/stat-boxplot.r
+++ b/R/stat-boxplot.r
@@ -45,7 +45,7 @@ StatBoxplot <- ggproto("StatBoxplot", Stat,
   required_aes = c("x", "y"),
   non_missing_aes = "weight",
 
-  setup_params = function(data, params) {
+  setup_params = function(data, params, spec) {
     params$width <- params$width %||% resolution(data$x) * 0.75
 
     if (is.double(data$x) && !has_groups(data) && any(data$x != data$x[1L])) {

--- a/R/stat-count.r
+++ b/R/stat-count.r
@@ -46,7 +46,7 @@ StatCount <- ggproto("StatCount", Stat,
   required_aes = "x",
   default_aes = aes(y = ..count..),
 
-  setup_params = function(data, params) {
+  setup_params = function(data, params, spec) {
     if (!is.null(data$y) || !is.null(params$y)) {
       stop("stat_count() must not be used with a y aesthetic.", call. = FALSE)
     }

--- a/R/stat-smooth.r
+++ b/R/stat-smooth.r
@@ -67,7 +67,7 @@ stat_smooth <- function(mapping = NULL, data = NULL,
 #' @export
 StatSmooth <- ggproto("StatSmooth", Stat,
 
-  setup_params = function(data, params) {
+  setup_params = function(data, params, spec) {
     # Figure out what type of smoothing to do: loess for small datasets,
     # gam with a cubic regression basis for large data
     # This is based on the size of the _largest_ group.

--- a/man/ggplot2-ggproto.Rd
+++ b/man/ggplot2-ggproto.Rd
@@ -213,9 +213,13 @@ implement one or more of the following:
     before the facets are trained, so they are global scales, not local
     to the individual panels.\code{...} contains the parameters returned by
     \code{setup_params()}.
-  \item \code{setup_params(data, params)}: called once for each layer.
+  \item \code{setup_params(data, params, spec)}: called once for each layer.
      Used to setup defaults that need to complete dataset, and to inform
      the user of important choices. Should return list of parameters.
+     The \code{spec} argument is a list containing information about the
+     facetting specification (slot \code{facet_spec}), the specification of
+     plot aesthetics (slot \code{plot_mapping}), and the specification of
+     the layer aesthetics (slot \code{layer_mapping}).
   \item \code{setup_data(data, params)}: called once for each layer,
      after \code{setp_params()}. Should return modified \code{data}.
      Default methods removes all rows containing a missing value in

--- a/vignettes/extending-ggplot2.Rmd
+++ b/vignettes/extending-ggplot2.Rmd
@@ -201,13 +201,13 @@ stat_lm <- function(mapping = NULL, data = NULL, geom = "line",
 
 Sometimes you have calculations that should be performed once for the complete dataset, not once for each group. This is useful for picking sensible default values. For example, if we want to do a density estimate, it's reasonable to pick one bandwidth for the whole plot. The following Stat creates a variation of the `stat_density()` that picks one bandwidth for all groups by choosing the mean of the "best" bandwidth for each group (I have no theoretical justification for this, but it doesn't seem unreasonable).
 
-To do this we override the `setup_params()` method. It's passed the data and a list of params, and returns an updated list.
+To do this we override the `setup_params()` method. It's passed the data, a list of params, and some information about how aesthetics are specified, and returns an updated list.
 
 ```{r}
 StatDensityCommon <- ggproto("StatDensityCommon", Stat, 
   required_aes = "x",
   
-  setup_params = function(data, params) {
+  setup_params = function(data, params, spec) {
     if (!is.null(params$bandwidth))
       return(params)
     
@@ -279,7 +279,7 @@ StatDensityCommon <- ggproto("StatDensityCommon", Stat,
   required_aes = "x",
   default_aes = aes(y = ..density..),
 
-  setup_params = function(data, params) {
+  setup_params = function(data, params, spec) {
     min <- min(data$x) - 3 * params$bandwidth
     max <- max(data$x) + 3 * params$bandwidth
     


### PR DESCRIPTION
I am writing a ggplot2 Stat that integrates fitted model into the grammar of graphics. Since it has to link the relevant grouping variables to the model predictors, the Stat requires knowledge of how all relevant aesthetics are specified and what faceting variables are active. For example it needs to know that `colour` has been specified with `factor(cyl)`. I could get this information by overwriting some Layer's method, but it would be much cleaner if that was part of the API.

So this PR proposes to add a `spec` argument to `setup_params()`. This has the downside of breaking the API but on the other hand adding a whole new method just for that does not seem appropriate. I ran a revdep check and, if I didn't miss anything, only four packages are broken by this change. Two of them because they have some custom version of `ggplot_build()` and the other two because they have overwritten `setup_params()` for a custom Stat. All those cases are trivial to fix and if this PR is merged I will send these projects a PR.

Also if Stats get to see the plot specification, we should probably do the same for Geoms. I added a similar `setup_params()` method to Geoms with `data`, `params` and `spec` arguments.

The `spec` object is defined as follows:

```{r}
spec <- function(layer, plot) {
  list(
    facet_spec = facet_spec(plot$facet),
    plot_mapping = plot$mapping,
    layer_mapping = layer$mapping
  )
}

facet_spec <- function(facet) {
  UseMethod("facet_spec")
}

facet_spec.wrap <- function(facet) {
  spec <- list(facets = facet$facets)
  structure(spec, class = c("wrap", "spec"))
}

facet_spec.grid <- function(facet) {
  spec <- list(rows = facet$rows, cols = facet$cols)
  structure(spec, class = c("grid", "spec"))
}
```
