### PR TITLE
Fix geom_dotplot y limit calculations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -75,6 +75,9 @@
 * Only one warning is issued when asking for too many levels in 
   `scale_discrete()` (#1674)
 
+* Fixed problem with `geom_dotplot()` when facetting and binning on the
+  y-axis. (#1618, @has2k1)
+
 # ggplot2 2.1.0
 
 ## New features

--- a/R/geom-dotplot.r
+++ b/R/geom-dotplot.r
@@ -238,7 +238,7 @@ GeomDotplot <- ggproto("GeomDotplot", Geom,
       # works. They're just set to the standard x +- width/2 so that dot clusters
       # can be dodged like other geoms.
       # After position code is rewritten, each dot should have its own bounding box.
-      data <- plyr::ddply(data, "group", transform,
+      data <- plyr::ddply(data, c("group", "PANEL"), transform,
             ymin = min(y) - binwidth[1] / 2,
             ymax = max(y) + binwidth[1] / 2)
 

--- a/tests/testthat/test-dotplot.r
+++ b/tests/testthat/test-dotplot.r
@@ -63,3 +63,17 @@ test_that("NA's result in warning from stat_bindot", {
   expect_warning(ggplot_build(ggplot(dat, aes(x)) + geom_dotplot(binwidth = .2)),
     "Removed 2 rows.*stat_bindot")
 })
+
+test_that("When binning on y-axis, limits depend on the panel", {
+   p <- ggplot(mtcars, aes(factor(cyl), mpg)) +
+        geom_dotplot(binaxis='y')
+
+   b1 <- ggplot_build(p + facet_wrap(~am))
+   b2 <- ggplot_build(p + facet_wrap(~am, scales = "free_y"))
+
+   equal_limits1 <- (b1$panel$ranges[[1]]$y.range == b1$panel$ranges[[2]]$y.range)
+   equal_limits2 <- (b2$panel$ranges[[1]]$y.range == b2$panel$ranges[[2]]$y.range)
+
+   expect_true(all(equal_limits1))
+   expect_false(all(equal_limits2))
+})


### PR DESCRIPTION
The computed y limits depend on both the group & panel.
This ensures that the scale trainning does not get wrong
(global y limits) input.

Fixes #1618