### PR TITLE
Preserve class when adding uneval objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@
 * Minor code formatting issues in examples and function parameters were
   fixed. (@hrbrmstr)
 
+* Class of aesthetic mapping is preserved when adding `aes()` objects. (#1624)
+
 # ggplot2 2.1.0
 
 ## New features

--- a/R/plot-construction.r
+++ b/R/plot-construction.r
@@ -92,6 +92,8 @@ add_ggplot <- function(p, object, objectname) {
     p <- update_guides(p, object)
   } else if (inherits(object, "uneval")) {
       p$mapping <- defaults(object, p$mapping)
+      # defaults() doesn't copy class, so copy it.
+      class(p$mapping) <- class(object)
 
       labels <- lapply(object, deparse)
       names(labels) <- names(object)

--- a/tests/testthat/test-add.R
+++ b/tests/testthat/test-add.R
@@ -1,0 +1,6 @@
+context("Adding plot elements")
+
+test_that("Mapping class is preserved when adding uneval objects", {
+  p <- ggplot(mtcars) + aes(wt, mpg)
+  expect_identical(class(p$mapping), "uneval")
+})


### PR DESCRIPTION
This fixes a bug that is the root cause of rstudio/shiny#1178. When adding an `aes()` object to a `ggplot()` object, the `uneval` class is inadvertently dropped. For example:


```R
# When including aes() in the ggplot() call, class is preserved
p <- ggplot(mtcars, aes(wt, mpg))
class(p$mapping)
# [1] "uneval"


# When adding aes() in the ggplot() call, class is lost
p <- ggplot(mtcars) + aes(wt, mpg)
class(p$mapping)
# [1] "list"
```


This PR preserves the class of the object.