### PR TITLE
Add top margin to default plot.caption

### DIFF
--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -137,7 +137,7 @@ theme_grey <- function(base_size = 11, base_family = "") {
     plot.caption =       element_text(
                            size = rel(0.9),
                            hjust = 1,
-                           margin = margin(b = half_line * 0.9)
+                           margin = margin(t = half_line * 0.9)
                          ),
     plot.margin =        margin(half_line, half_line, half_line, half_line),
 


### PR DESCRIPTION
According to an informal survey (@hrbrmstr @juliasilge), this margin is needed every time a plot.caption is used:
https://twitter.com/janschulz/status/727932334218039296

The chosen top margin is the same as for the subtitle, just on the top instead
of the bottom.