### PR TITLE
Use validate_params = FALSE to pass unvalidated params as a list

### DIFF
--- a/R/layer.r
+++ b/R/layer.r
@@ -113,7 +113,7 @@ layer <- function(geom = NULL, stat = NULL,
   }else if (length(extra) > 0) {
     extra <- extra[!extra == "validate_params"]
     warning("Unknown parameters used: ", paste(extra, collapse = ", "), 
-            "\nSet validate_params to TRUE avoid errors", call. = FALSE)
+            "\nSet validate_params to TRUE to avoid errors", call. = FALSE)
     extra_params <- params[extra]
   }
   

--- a/R/layer.r
+++ b/R/layer.r
@@ -112,8 +112,6 @@ layer <- function(geom = NULL, stat = NULL,
     stop("Unknown parameters: ", paste(extra, collapse = ", "), call. = FALSE)
   }else if (length(extra) > 0) {
     extra <- extra[!extra == "validate_params"]
-    warning("Unknown parameters used: ", paste(extra, collapse = ", "), 
-            "\nSet validate_params to TRUE to avoid errors", call. = FALSE)
     extra_params <- params[extra]
   }
   

--- a/R/layer.r
+++ b/R/layer.r
@@ -110,7 +110,7 @@ layer <- function(geom = NULL, stat = NULL,
   
   if (length(extra) > 0 && params$validate_params) {
     stop("Unknown parameters: ", paste(extra, collapse = ", "), call. = FALSE)
-  }else{
+  }else if (length(extra) > 0) {
     extra <- extra[!extra == "validate_params"]
     warning("Unknown parameters used: ", paste(extra, collapse = ", "), 
             "\nSet validate_params to TRUE avoid errors", call. = FALSE)

--- a/R/layer.r
+++ b/R/layer.r
@@ -101,10 +101,22 @@ layer <- function(geom = NULL, stat = NULL,
 
   all <- c(geom$parameters(TRUE), stat$parameters(TRUE), geom$aesthetics())
   extra <- setdiff(names(params), all)
-  if (length(extra) > 0) {
-    stop("Unknown parameters: ", paste(extra, collapse = ", "), call. = FALSE)
+  
+  # Handle extra params
+  if (is.null(params$validate_params)) {
+    params$validate_params <- TRUE
+    extra_params <- NULL
   }
-
+  
+  if (length(extra) > 0 && params$validate_params) {
+    stop("Unknown parameters: ", paste(extra, collapse = ", "), call. = FALSE)
+  }else{
+    extra <- extra[!extra == "validate_params"]
+    warning("Unknown parameters used: ", paste(extra, collapse = ", "), 
+            "\nSet validate_params to TRUE avoid errors", call. = FALSE)
+    extra_params <- params[extra]
+  }
+  
   ggproto("LayerInstance", Layer,
     geom = geom,
     geom_params = geom_params,
@@ -116,7 +128,8 @@ layer <- function(geom = NULL, stat = NULL,
     subset = subset,
     position = position,
     inherit.aes = inherit.aes,
-    show.legend = show.legend
+    show.legend = show.legend,
+    extra_params = extra_params
   )
 }
 
@@ -130,6 +143,7 @@ Layer <- ggproto("Layer", NULL,
   mapping = NULL,
   position = NULL,
   inherit.aes = FALSE,
+  extra_params = NULL,
 
   print = function(self) {
     if (!is.null(self$mapping)) {

--- a/tests/testthat/test-layer.r
+++ b/tests/testthat/test-layer.r
@@ -17,11 +17,8 @@ test_that("Unknown params create error with validate_params = TRUE", {
                "Unknown parameters")
 })
 
-test_that("Unknown params create warning with validate_params = FALSE", {
-  expect_warning(geom_point(blah = "red", validate_params = FALSE),
-                 paste("Unknown parameters used: blah",
-                       "Set validate_params to TRUE to avoid errors",
-                       sep = "\n"))
+test_that("Unknown params don't create error with validate_params = FALSE", {
+  expect_silent(geom_point(blah = "red", validate_params = FALSE))
 })
 
 test_that("Unknown params go in extra_params, not aes_params", {

--- a/tests/testthat/test-layer.r
+++ b/tests/testthat/test-layer.r
@@ -12,6 +12,26 @@ test_that("unknown params create error", {
   expect_error(geom_point(blah = "red"), "Unknown parameters")
 })
 
+test_that("Unknown params create error with validate_params = TRUE", {
+  expect_error(geom_point(blah = "red", validate_params = TRUE),
+               "Unknown parameters")
+})
+
+test_that("Unknown params create warning with validate_params = FALSE", {
+  expect_warning(geom_point(blah = "red", validate_params = FALSE),
+                 paste("Unknown parameters used: blah",
+                       "Set validate_params to TRUE to avoid errors",
+                       sep = "\n"))
+})
+
+test_that("Unknown params go in extra_params, not aes_params", {
+  l <- geom_point(some_param = "value1",
+                  size = "big",
+                  validate_params = FALSE)
+  expect_equal(l$extra_params, list(some_param = "value1"))
+  expect_equal(l$aes_params, list(size = "big"))
+})
+
 # Calculated aesthetics ---------------------------------------------------
 
 test_that("Bare name surround by .. is calculated", {


### PR DESCRIPTION
This PR is with respect to [this comment about passing additional parameters](https://github.com/hadley/ggplot2/issues/1585#issuecomment-225583280).

The motivation of this PR is that packages like Animint depend on additional params to produce plots and animations using ggplot.

After the changes, the following code will still produce the same error as before:
```
library("ggplot2")

viz <- list(iris=ggplot()+
    geom_point(aes(Petal.Width, Sepal.Length, showSelected=Species),
               data=iris, chunk_vars=character()))
```
```
Error: Unknown parameters: chunk_vars
```

While this code will only produce a warning and pass the additional params as a list `extra_params`:
```
library("ggplot2")

viz <- list(iris=ggplot()+
    geom_point(aes(Petal.Width, Sepal.Length, showSelected=Species),
               data=iris, chunk_vars=character(),validate_params = F))
```
```
Warning message:
Unknown parameters used: chunk_vars
Set validate_params to TRUE avoid errors 
```
This way we will be able to access these params through the `extra_params` list under `plot$layers` and use them in development of other packages, and the general user should still see the same error as before, unless he/she specifies the `validate_params` option. I think this achieves both the goals.

EDIT: Please see my other comment below for changes.