### PR TITLE
Expose argument n from stats::density in the interface of stat_density.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # ggplot2 2.1.0.9000 
 
+
 * `position_stack()` and `position_fill()` now sorts the stacking order so it 
   matches the order of the grouping. Use level reordering to alter the stacking 
   order. The default legend and stacking order is now also in line. The default 
@@ -27,6 +28,10 @@
   even if you haven't explicitly loaded tibble or dplyr (#1677).
 
 * `stat_ecdf()` respects `pad` argument (#1646).
+
+* `stat_density` now makes argument `n` of the unterlying function
+  `stats::density` ("number of equally spaced points at which the
+  density is to be estimated") accessible. (@hbuschme)
 
 * `x` and `y` scales are now symmetric regarding the list of
   aesthetics they accept: `xmin_final`, `xmax_final`, `xlower`,

--- a/R/stat-density.r
+++ b/R/stat-density.r
@@ -4,6 +4,8 @@
 #'   \code{\link{density}} for details
 #' @param kernel kernel used for density estimation, see
 #'   \code{\link{density}} for details
+#' @param n number of equally spaced points at which the density is to be
+#'   estimated, see \code{\link{density}} for details
 #' @param trim This parameter only matters if you are displaying multiple
 #'   densities in one plot. If \code{FALSE}, the default, each density is
 #'   computed on the full range of the data. If \code{TRUE}, each density
@@ -25,6 +27,7 @@ stat_density <- function(mapping = NULL, data = NULL,
                          bw = "nrd0",
                          adjust = 1,
                          kernel = "gaussian",
+                         n = 512,
                          trim = FALSE,
                          na.rm = FALSE,
                          show.legend = NA,
@@ -42,6 +45,7 @@ stat_density <- function(mapping = NULL, data = NULL,
       bw = bw,
       adjust = adjust,
       kernel = kernel,
+      n = n,
       trim = trim,
       na.rm = na.rm,
       ...
@@ -58,7 +62,7 @@ StatDensity <- ggproto("StatDensity", Stat,
   default_aes = aes(y = ..density.., fill = NA),
 
   compute_group = function(data, scales, bw = "nrd0", adjust = 1, kernel = "gaussian",
-                           trim = FALSE, na.rm = FALSE) {
+                           n = 512, trim = FALSE, na.rm = FALSE) {
     if (trim) {
       range <- range(data$x, na.rm = TRUE)
     } else {
@@ -66,37 +70,37 @@ StatDensity <- ggproto("StatDensity", Stat,
     }
 
     compute_density(data$x, data$weight, from = range[1], to = range[2],
-      bw = bw, adjust = adjust, kernel = kernel)
+      bw = bw, adjust = adjust, kernel = kernel, n = n)
   }
 
 )
 
 compute_density <- function(x, w, from, to, bw = "nrd0", adjust = 1,
-                            kernel = "gaussian") {
-  n <- length(x)
+                            kernel = "gaussian", n = 512) {
+  nx <- length(x)
   if (is.null(w)) {
-    w <- rep(1 / n, n)
+    w <- rep(1 / nx, nx)
   }
 
   # if less than 3 points, spread density evenly over points
-  if (n < 3) {
+  if (nx < 3) {
     return(data.frame(
       x = x,
       density = w / sum(w),
       scaled = w / max(w),
       count = 1,
-      n = n
+      n = nx
     ))
   }
 
   dens <- stats::density(x, weights = w, bw = bw, adjust = adjust,
-    kernel = kernel, from = from, to = to)
+    kernel = kernel, n = n, from = from, to = to)
 
   data.frame(
     x = dens$x,
     density = dens$y,
     scaled =  dens$y / max(dens$y, na.rm = TRUE),
-    count =   dens$y * n,
-    n = n
+    count =   dens$y * nx,
+    n = nx
   )
 }

--- a/R/stat-density.r
+++ b/R/stat-density.r
@@ -5,7 +5,8 @@
 #' @param kernel kernel used for density estimation, see
 #'   \code{\link{density}} for details
 #' @param n number of equally spaced points at which the density is to be
-#'   estimated, see \code{\link{density}} for details
+#'   estimated, should be a power of two, see \code{\link{density}} for
+#'   details
 #' @param trim This parameter only matters if you are displaying multiple
 #'   densities in one plot. If \code{FALSE}, the default, each density is
 #'   computed on the full range of the data. If \code{TRUE}, each density

--- a/man/geom_density.Rd
+++ b/man/geom_density.Rd
@@ -11,7 +11,8 @@ geom_density(mapping = NULL, data = NULL, stat = "density",
 
 stat_density(mapping = NULL, data = NULL, geom = "area",
   position = "stack", ..., bw = "nrd0", adjust = 1, kernel = "gaussian",
-  trim = FALSE, na.rm = FALSE, show.legend = NA, inherit.aes = TRUE)
+  n = 512, trim = FALSE, na.rm = FALSE, show.legend = NA,
+  inherit.aes = TRUE)
 }
 \arguments{
 \item{mapping}{Set of aesthetic mappings created by \code{\link{aes}} or
@@ -64,6 +65,9 @@ the default plot specification, e.g. \code{\link{borders}}.}
 
 \item{kernel}{kernel used for density estimation, see
 \code{\link{density}} for details}
+
+\item{n}{number of equally spaced points at which the density is to be
+estimated, see \code{\link{density}} for details}
 
 \item{trim}{This parameter only matters if you are displaying multiple
 densities in one plot. If \code{FALSE}, the default, each density is

--- a/man/geom_density.Rd
+++ b/man/geom_density.Rd
@@ -67,7 +67,8 @@ the default plot specification, e.g. \code{\link{borders}}.}
 \code{\link{density}} for details}
 
 \item{n}{number of equally spaced points at which the density is to be
-estimated, see \code{\link{density}} for details}
+estimated, should be a power of two, see \code{\link{density}} for
+details}
 
 \item{trim}{This parameter only matters if you are displaying multiple
 densities in one plot. If \code{FALSE}, the default, each density is


### PR DESCRIPTION
The argument controls the number of equally spaced points at which the density is to be estimated. As in `stats::density` the argument `n` defaults to 512. It is exposed through the function interface of `stat_density` and can thus also be used from `geom_density`.

An existent local variable `n`, which holds the number of values in the input vector, has been renamed to `nx` to avoid a name clash.

I needed this argument because plots created with `geom_density` contained a large number of points (1024?) per density curve. This resulted in large file sizes when saving the plot as a vector graphic. I think that it is generally useful to be able to control this parameter of the density function.

I rebuild the documentation, and tested the new functionality. However, I added a new argument to an existing function and – not being an R expert – I am not sure whether this might break someones code. The argument has a default value, but I did not add it at the very end of the argument list but rather at a point where it seemed fitting.