### PR TITLE
docs: reorder theme_gray in examples so it's clear what it does

### DIFF
--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -45,7 +45,6 @@
 #'      colour = factor(gear))) + facet_wrap(~am)
 #'
 #' p
-#' p + theme_gray()
 #' p + theme_bw()
 #' p + theme_linedraw()
 #' p + theme_light()
@@ -53,6 +52,7 @@
 #' p + theme_minimal()
 #' p + theme_classic()
 #' p + theme_void()
+#' p + theme_gray() # default theme
 #'
 #' @name ggtheme
 NULL

--- a/man/ggtheme.Rd
+++ b/man/ggtheme.Rd
@@ -80,7 +80,6 @@ p <- ggplot(mtcars) + geom_point(aes(x = wt, y = mpg,
      colour = factor(gear))) + facet_wrap(~am)
 
 p
-p + theme_gray()
 p + theme_bw()
 p + theme_linedraw()
 p + theme_light()
@@ -88,6 +87,7 @@ p + theme_dark()
 p + theme_minimal()
 p + theme_classic()
 p + theme_void()
+p + theme_gray() # default theme
 
 }
 


### PR DESCRIPTION
Small but clarifying change. I encountered a user who was confused why `p + theme_gray()` didn't update the plot when the examples were run in succession. 

I reordered examples so it does change the current plot. Also, commented that it is the default, in case the reader jumps right to the examples.