### PR TITLE
Allow separate expansion values for lower and upper range limits.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,28 @@
 # ggplot2 2.1.0.9000 
 
+* The `expand` argument for `scale_*_continuous()` and
+  `scale_*_discrete()` now accepts separate expansion
+  constants for the lower and upper range limits.
+  
+  This makes it much easier to create bar charts where the
+  bottom of the bars are flush with the x axis but the bars
+  still have some (automatically calculated amount of) space
+  above them:
+  
+    ```R
+    ggplot(mtcars) +
+        geom_bar(aes(x = cyl)) +
+        scale_y_continuous(expand = c(0, 0, 0.05, 0))
+    ```
+
+  The syntax for the multiplicative and additive expansion
+  constants has been changed from `c(m, a)` to
+  `c(m_lower, a_lower, m_uppper, a_upper)`. The old syntax
+  will still work, as length 2 vectors `c(m, a)` are
+  expanded to `c(m, a, m, a)` and length 3 vectors
+  are expanded from `c(m1, a1, m2)` to `c(m1, a2, m2, a1)`.
+  (@huftis, #1669)
+
 * `x` and `y` scales are now symmetric regarding the list of
   aesthetics they accept: `xmin_final`, `xmax_final`, `xlower`,
   `xmiddle` and `xupper` are now valid `x` aesthetics.

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -200,8 +200,16 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
     ifelse(!is.na(scaled), scaled, self$na.value)
   },
 
-  dimension = function(self, expand = c(0, 0)) {
-    expand_range(self$get_limits(), expand[1], expand[2])
+  dimension = function(self, expand = c(0, 0, 0, 0)) {
+    # If not all four expansion constants are given,
+    # reuse the ones that *are* given (or use a sensible
+    # default of 0 if zero or one are given).
+    if (length(expand) < 2)  { expand <- c(expand, 0, 0)[1:2] }
+    if (length(expand) == 2) { expand <- c(expand, expand) }
+    if (length(expand) == 3) { expand <- c(expand, expand[2]) }
+    lower <- expand_range(self$get_limits(), expand[1], expand[2])[1]
+    upper <- expand_range(self$get_limits(), expand[3], expand[4])[2]
+    c(lower, upper)
   },
 
   get_breaks = function(self, limits = self$get_limits()) {
@@ -371,8 +379,16 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
     ifelse(is.na(x) | is.na(pal_match), self$na.value, pal_match)
   },
 
-  dimension = function(self, expand = c(0, 0)) {
-    expand_range(length(self$get_limits()), expand[1], expand[2])
+  dimension = function(self, expand = c(0, 0, 0, 0)) {
+    # If not all four expansion constants are given,
+    # reuse the ones that *are* given (or use a sensible
+    # default of 0 if zero or one are given).
+    if (length(expand) < 2)  { expand <- c(expand, 0, 0)[1:2] }
+    if (length(expand) == 2) { expand <- c(expand, expand) }
+    if (length(expand) == 3) { expand <- c(expand, expand[2]) }
+    lower <- expand_range(self$get_limits(), expand[1], expand[2])[1]
+    upper <- expand_range(self$get_limits(), expand[3], expand[4])[2]
+    c(lower, upper)
   },
 
   get_breaks = function(self, limits = self$get_limits()) {
@@ -510,11 +526,15 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
 #'   are defined in the scales package, and are called \code{name_trans}, e.g.
 #'   \code{\link[scales]{boxcox_trans}}. You can create your own
 #'   transformation with \code{\link[scales]{trans_new}}.
-#' @param expand A numeric vector of length two giving multiplicative and
-#'   additive expansion constants. These constants ensure that the data is
-#'   placed some distance away from the axes. The defaults are
-#'   \code{c(0.05, 0)} for continuous variables, and \code{c(0, 0.6)} for
-#'   discrete variables.
+#' @param expand A numeric vector of length four, giving multiplicative
+#'   (1st and 3d element) and additive (2nd and 4th element) range expansion constants.
+#'   These constants ensure that the data is placed some distance away from the axes.
+#'   The first two elements specify the expansion for the lower limit, and the last
+#'   two for the upper limit. The specified vector can also be of length two or three,
+#'   and the constants for the lower limit are then reused for the upper limit,
+#'   i.e. \code{c(a, b)} is equivalent to \code{c(a, b, a, b)} and \code{c(a, b, c)}
+#'   is equivalent to \code{c(a, b, c, b)}. The defaults are \code{c(0.05, 0)} for
+#'   continuous variables, and \code{c(0, 0.6)} for discrete variables.
 #' @param guide Name of guide object, or object itself.
 #' @keywords internal
 continuous_scale <- function(aesthetics, scale_name, palette, name = waiver(),

--- a/R/scale-discrete-.r
+++ b/R/scale-discrete-.r
@@ -114,20 +114,43 @@ ScaleDiscretePosition <- ggproto("ScaleDiscretePosition", ScaleDiscrete,
     }
   },
 
-  dimension = function(self, expand = c(0, 0)) {
+  dimension = function(self, expand = c(0, 0, 0, 0)) {
     c_range <- self$range_c$range
     d_range <- self$range$range
+    
+    # If not all four expansion constants are given,
+    # reuse the ones that *are* given (or use sensible
+    # defaults if zero or one are given).
+    if (length(expand) == 0) {
+      expand <- c(0, 1)
+    } else if (length(expand) == 1) {
+      expand <- c(expand, 1)
+    }
+    if (length(expand) == 2) {
+      expand <- c(expand, expand)
+    } else if (length(expand) == 3) {
+      expand <- c(expand, expand[2])
+    }
+    
+    # Similar to expand_range(), but taking *four* expansion arguments
+    # (1st and 2n elements are used for the lower limit, and the
+    # 3rd and 4th elements are used for the upper limit).
+    expand_range4 <- function(limits, m1, a1, m2, a2) {
+      lower <- expand_range(limits, m1, a1)[1]
+      upper <- expand_range(limits, m2, a2)[2]
+      c(lower, upper)
+    }
 
     if (self$is_empty()) {
       c(0, 1)
     } else if (is.null(d_range)) { # only continuous
-      expand_range(c_range, expand[1], 0 , 1)
+      expand_range4(c_range, expand[1], 0, expand[3], 0)
     } else if (is.null(c_range)) { # only discrete
-      expand_range(c(1, length(d_range)), 0, expand[2], 1)
+      expand_range4(c(1, length(d_range)), 0, expand[2], 0, expand[4])
     } else { # both
       range(
-        expand_range(c_range, expand[1], 0 , 1),
-        expand_range(c(1, length(d_range)), 0, expand[2], 1)
+        expand_range4(c_range, expand[1], 0, expand[3], 0),
+        expand_range4(c(1, length(d_range)), 0, expand[2], 0, expand[4])
       )
     }
   },

--- a/man/continuous_scale.Rd
+++ b/man/continuous_scale.Rd
@@ -58,11 +58,15 @@ A function used to scale the input values to the range [0, 1].}
 \item{oob}{Function that handles limits outside of the scale limits
 (out of bounds). The default replaces out of bounds values with NA.}
 
-\item{expand}{A numeric vector of length two giving multiplicative and
-additive expansion constants. These constants ensure that the data is
-placed some distance away from the axes. The defaults are
-\code{c(0.05, 0)} for continuous variables, and \code{c(0, 0.6)} for
-discrete variables.}
+\item{expand}{A numeric vector of length four, giving multiplicative
+(1st and 3d element) and additive (2nd and 4th element) range expansion constants.
+These constants ensure that the data is placed some distance away from the axes.
+The first two elements specify the expansion for the lower limit, and the last
+two for the upper limit. The specified vector can also be of length two or three,
+and the constants for the lower limit are then reused for the upper limit,
+i.e. \code{c(a, b)} is equivalent to \code{c(a, b, a, b)} and \code{c(a, b, c)}
+is equivalent to \code{c(a, b, c, b)}. The defaults are \code{c(0.05, 0)} for
+continuous variables, and \code{c(0, 0.6)} for discrete variables.}
 
 \item{na.value}{Missing values will be replaced with this value.}
 

--- a/man/labs.Rd
+++ b/man/labs.Rd
@@ -19,7 +19,7 @@ ggtitle(label, subtitle = NULL)
 \arguments{
 \item{...}{a list of new names in the form aesthetic = "new name"}
 
-\item{label}{The text for the axis, plot title or caption below the plot}
+\item{label}{The text for the axis, plot title or caption below the plot.}
 
 \item{subtitle}{the text for the subtitle for the plot which will be
 displayed below the title. Leave \code{NULL} for no subtitle.}

--- a/man/scale_continuous.Rd
+++ b/man/scale_continuous.Rd
@@ -68,11 +68,15 @@ mapping used for that aesthetic.}
 \item{limits}{A numeric vector of length two providing limits of the scale.
 Use \code{NA} to refer to the existing minimum or maximum.}
 
-\item{expand}{A numeric vector of length two giving multiplicative and
-additive expansion constants. These constants ensure that the data is
-placed some distance away from the axes. The defaults are
-\code{c(0.05, 0)} for continuous variables, and \code{c(0, 0.6)} for
-discrete variables.}
+\item{expand}{A numeric vector of length four, giving multiplicative
+(1st and 3d element) and additive (2nd and 4th element) range expansion constants.
+These constants ensure that the data is placed some distance away from the axes.
+The first two elements specify the expansion for the lower limit, and the last
+two for the upper limit. The specified vector can also be of length two or three,
+and the constants for the lower limit are then reused for the upper limit,
+i.e. \code{c(a, b)} is equivalent to \code{c(a, b, a, b)} and \code{c(a, b, c)}
+is equivalent to \code{c(a, b, c, b)}. The defaults are \code{c(0.05, 0)} for
+continuous variables, and \code{c(0, 0.6)} for discrete variables.}
 
 \item{oob}{Function that handles limits outside of the scale limits
 (out of bounds). The default replaces out of bounds values with NA.}

--- a/man/scale_date.Rd
+++ b/man/scale_date.Rd
@@ -72,11 +72,15 @@ like "2 weeks", or "10 years". If both \code{minor_breaks} and
 \item{limits}{A numeric vector of length two providing limits of the scale.
 Use \code{NA} to refer to the existing minimum or maximum.}
 
-\item{expand}{A numeric vector of length two giving multiplicative and
-additive expansion constants. These constants ensure that the data is
-placed some distance away from the axes. The defaults are
-\code{c(0.05, 0)} for continuous variables, and \code{c(0, 0.6)} for
-discrete variables.}
+\item{expand}{A numeric vector of length four, giving multiplicative
+(1st and 3d element) and additive (2nd and 4th element) range expansion constants.
+These constants ensure that the data is placed some distance away from the axes.
+The first two elements specify the expansion for the lower limit, and the last
+two for the upper limit. The specified vector can also be of length two or three,
+and the constants for the lower limit are then reused for the upper limit,
+i.e. \code{c(a, b)} is equivalent to \code{c(a, b, a, b)} and \code{c(a, b, c)}
+is equivalent to \code{c(a, b, c, b)}. The defaults are \code{c(0.05, 0)} for
+continuous variables, and \code{c(0, 0.6)} for discrete variables.}
 }
 \description{
 Use \code{scale_*_date} with \code{Date} variables, and


### PR DESCRIPTION
Fixes #1669 

The `expand` argument for `scale_*_continuous()` and
`scale_*_discrete()` now accepts separate expansion
constants for the lower and upper range limits.

This makes it much easier to create bar charts where the
bottom of the bars are flush with the x axis but the bars
still have some (automatically calculated amount of) space
above them:

```R
ggplot(mtcars) +
geom_bar(aes(x = cyl)) +
scale_y_continuous(expand = c(0, 0, 0.05, 0))
```

The syntax for the multiplicative and additive expansion
constants has been changed from `c(m, a)` to
`c(m_lower, a_lower, m_uppper, a_upper)`. The old syntax
will still work, as length 2 vectors `c(m, a)` are
expanded to `c(m, a, m, a)` and length 3 vectors
are expanded from `c(m1, a1, m2)` to `c(m1, a2, m2, a1)`.
(@huftis, #1669)

Some examples:

```R
# Continuous scales
p = ggplot(mtcars) +
      geom_bar(aes(x = cyl))
  
# No space below but 5% space above bars
p + scale_y_continuous(expand = c(0, 0, 0.05, 0))

# 3 units space below and 1 unit space above bars
p + scale_x_continuous(expand = c(0, 3, 0, 1))

# It also works with facets
p + facet_wrap(~cyl) +
    scale_y_continuous(expand = c(0, 0, 0.05))
p + facet_wrap(~cyl, scales="free_y") +
    scale_y_continuous(expand = c(0, 0, 0.05))
# Note that all the bars should look identical in this last example

# Coordinate flipping also works
p + scale_y_continuous(expand = c(.5, 0, 0.05, 0)) +
    coord_flip()
p + scale_y_continuous(expand = c(0, 2, 0, 5)) +
    coord_flip()


# Similar examples for discrete scales

d <- ggplot(subset(diamonds, carat > 1), aes(cut, clarity)) +
  geom_jitter()

d + scale_x_discrete(expand = c(.25, 0))
d + scale_x_discrete(expand = c(0, 1))
d + scale_x_discrete(expand = c(0, 1, 0, 5))
d + scale_x_discrete(expand = c(.25, 0, .5, 0))
d + scale_x_discrete(expand = c(.25, 1, .25, 5))
d + scale_x_discrete(expand = c(.25, 1, .25, 5)) + coord_flip()
```