### PR TITLE
Typo in the documentation of resolution() function

### DIFF
--- a/R/utilities-resolution.r
+++ b/R/utilities-resolution.r
@@ -1,6 +1,6 @@
 #' Compute the "resolution" of a data vector.
 #'
-#' The resolution is is the smallest non-zero distance between adjacent
+#' The resolution is the smallest non-zero distance between adjacent
 #' values.  If there is only one unique value, then the resolution is defined
 #' to be one.
 #'

--- a/man/resolution.Rd
+++ b/man/resolution.Rd
@@ -13,7 +13,7 @@ resolution(x, zero = TRUE)
 computation of resolution}
 }
 \description{
-The resolution is is the smallest non-zero distance between adjacent
+The resolution is the smallest non-zero distance between adjacent
 values.  If there is only one unique value, then the resolution is defined
 to be one.
 }


### PR DESCRIPTION
This pull request fixes a minor typo I found in the documentation