### PR TITLE
Fix annotate without global data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,9 @@
 
 * Fix error message of Stats ggprotos when required aesthetics are
   missing.
+  
+* Fix bug that resulted in several annotation_x function not getting drawn when
+  global data was lacking (#1655)
 
 # ggplot2 2.1.0
 

--- a/R/annotation-custom.r
+++ b/R/annotation-custom.r
@@ -42,11 +42,11 @@ NULL
 #'   annotation_custom(grob = g, xmin = 1, xmax = 10, ymin = 8, ymax = 10)
 annotation_custom <- function(grob, xmin = -Inf, xmax = Inf, ymin = -Inf, ymax = Inf) {
   layer(
-    data = NULL,
+    data = dummy_data(),
     stat = StatIdentity,
     position = PositionIdentity,
     geom = GeomCustomAnn,
-    inherit.aes = TRUE,
+    inherit.aes = FALSE,
     params = list(
       grob = grob,
       xmin = xmin,

--- a/R/annotation-logticks.r
+++ b/R/annotation-logticks.r
@@ -81,7 +81,7 @@ annotation_logticks <- function(base = 10, sides = "bl", scaled = TRUE,
     colour <- color
 
   layer(
-    data = data.frame(x = NA),
+    data = dummy_data(),
     mapping = NULL,
     stat = StatIdentity,
     geom = GeomLogticks,

--- a/R/annotation-map.r
+++ b/R/annotation-map.r
@@ -34,7 +34,7 @@ annotation_map <- function(map, ...) {
   stopifnot(all(c("x", "y", "id") %in% names(map)))
 
   layer(
-    data = NULL,
+    data = dummy_data(),
     stat = StatIdentity,
     geom = GeomAnnotationMap,
     position = PositionIdentity,

--- a/R/annotation-raster.r
+++ b/R/annotation-raster.r
@@ -43,12 +43,12 @@ annotation_raster <- function(raster, xmin, xmax, ymin, ymax,
   raster <- grDevices::as.raster(raster)
 
   layer(
-    data = NULL,
+    data = dummy_data(),
     mapping = NULL,
     stat = StatIdentity,
     position = PositionIdentity,
     geom = GeomRasterAnn,
-    inherit.aes = TRUE,
+    inherit.aes = FALSE,
     params = list(
       raster = raster,
       xmin = xmin,

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -281,6 +281,10 @@ dispatch_args <- function(f, ...) {
   f
 }
 
+# Used in annotations to ensure printed even when no
+# global data
+dummy_data <- function() data.frame(x = NA)
+
 # Needed to trigger package loading
 #' @importFrom tibble tibble
 NULL

--- a/tests/testthat/test-annotate.r
+++ b/tests/testthat/test-annotate.r
@@ -26,3 +26,23 @@ test_that("segment annotations transform with scales", {
     annotate("segment", x = 2, y = 10, xend = 5, yend = 30, colour = "red") +
     scale_y_reverse()
 })
+
+test_that("annotation_* has dummy data assigned and don't inherit aes", {
+  custom <- annotation_custom(zeroGrob())
+  logtick <- annotation_logticks()
+  library(maps)
+  usamap <- map_data("state")
+  map <- annotation_map(usamap)
+  rainbow <- matrix(hcl(seq(0, 360, length.out = 50 * 50), 80, 70), nrow = 50)
+  raster <- annotation_raster(rainbow, 15, 20, 3, 4)
+  dummy <- dummy_data()
+  expect_equal(custom$data, dummy)
+  expect_equal(logtick$data, dummy)
+  expect_equal(map$data, dummy)
+  expect_equal(raster$data, dummy)
+
+  expect_false(custom$inherit.aes)
+  expect_false(logtick$inherit.aes)
+  expect_false(map$inherit.aes)
+  expect_false(raster$inherit.aes)
+})


### PR DESCRIPTION
This fixes #1655 by adding dummy data to all annotate functions in the way already done for annotate_logticks.