### PR TITLE
`expand` parameter can now be used selectively

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # ggplot2 2.1.0.9000 
 
+* `coord_cartesian()`, `coord_flip()`, `coord_fixed()`, and `coord_map()`
+  now also accept a logical vector of length 4 for 
+  `expand` parameter. e.g.: `coord_cartesian(expand = c(T, F, T, T))`. The 4 
+  elements of expand refer to the left, right, bottom and top edges of the 
+  plot in that order. (@sainathadapa)
+
 * `stat_bin()` and `stat_summary_hex()` now accept length 1 `binwidth` (#1610)
 
 * `geom_histogram()` and `stat_bin()` understand the `breaks` parameter once 

--- a/R/coord-cartesian-.r
+++ b/R/coord-cartesian-.r
@@ -54,7 +54,7 @@
 #' # By default, the expansion factor is applied to all the four edges.
 #' # You can change this by giving a logical vector of length 4. In the
 #' # following example, only the left and top edges are expanded.
-#' p + coord_cartesian(expand = c(T, F, F, T))
+#' p + coord_cartesian(expand = c(TRUE, FALSE, FALSE, TRUE))
 coord_cartesian <- function(xlim = NULL, ylim = NULL, expand = TRUE) {
   ggproto(NULL, CoordCartesian,
     limits = list(x = xlim, y = ylim),

--- a/man/coord_cartesian.Rd
+++ b/man/coord_cartesian.Rd
@@ -11,7 +11,10 @@ coord_cartesian(xlim = NULL, ylim = NULL, expand = TRUE)
 
 \item{expand}{If \code{TRUE}, the default, adds a small expansion factor to
 the limits to ensure that data and axes don't overlap. If \code{FALSE},
-limits are taken exactly from the data or \code{xlim}/\code{ylim}.}
+limits are taken exactly from the data or \code{xlim}/\code{ylim}. If
+a logical vector of length 4 (e.g.: \code{c(TRUE, FALSE, FALSE, TRUE)}),
+the expansion factor is selectively applied. The 4 elements will refer to the
+left, right, bottom and top edges of the plot in that order.}
 }
 \description{
 The Cartesian coordinate system is the most familiar, and common, type of
@@ -56,5 +59,10 @@ d + scale_x_continuous(limits = c(0, 1))
 # When zooming the coordinate system, we see a subset of original 50 bins,
 # displayed bigger
 d + coord_cartesian(xlim = c(0, 1))
+
+# By default, the expansion factor is applied to all the four edges.
+# You can change this by giving a logical vector of length 4. In the
+# following example, only the left and top edges are expanded.
+p + coord_cartesian(expand = c(T, F, F, T))
 }
 

--- a/man/coord_cartesian.Rd
+++ b/man/coord_cartesian.Rd
@@ -63,6 +63,6 @@ d + coord_cartesian(xlim = c(0, 1))
 # By default, the expansion factor is applied to all the four edges.
 # You can change this by giving a logical vector of length 4. In the
 # following example, only the left and top edges are expanded.
-p + coord_cartesian(expand = c(T, F, F, T))
+p + coord_cartesian(expand = c(TRUE, FALSE, FALSE, TRUE))
 }
 

--- a/man/coord_fixed.Rd
+++ b/man/coord_fixed.Rd
@@ -16,7 +16,10 @@ coord_fixed(ratio = 1, xlim = NULL, ylim = NULL, expand = TRUE)
 
 \item{expand}{If \code{TRUE}, the default, adds a small expansion factor to
 the limits to ensure that data and axes don't overlap. If \code{FALSE},
-limits are taken exactly from the data or \code{xlim}/\code{ylim}.}
+limits are taken exactly from the data or \code{xlim}/\code{ylim}. If
+a logical vector of length 4 (e.g.: \code{c(TRUE, FALSE, FALSE, TRUE)}),
+the expansion factor is selectively applied. The 4 elements will refer to the
+left, right, bottom and top edges of the plot in that order.}
 }
 \description{
 A fixed scale coordinate system forces a specified ratio between the

--- a/man/coord_flip.Rd
+++ b/man/coord_flip.Rd
@@ -13,7 +13,10 @@ coord_flip(xlim = NULL, ylim = NULL, expand = TRUE)
 
 \item{expand}{If \code{TRUE}, the default, adds a small expansion factor to
 the limits to ensure that data and axes don't overlap. If \code{FALSE},
-limits are taken exactly from the data or \code{xlim}/\code{ylim}.}
+limits are taken exactly from the data or \code{xlim}/\code{ylim}. If
+a logical vector of length 4 (e.g.: \code{c(TRUE, FALSE, FALSE, TRUE)}),
+the expansion factor is selectively applied. The 4 elements will refer to the
+left, right, bottom and top edges of the plot in that order.}
 }
 \description{
 Flipped cartesian coordinates so that horizontal becomes vertical, and

--- a/man/coord_map.Rd
+++ b/man/coord_map.Rd
@@ -28,7 +28,10 @@ projections, so you will have to supply your own. See
 
 \item{expand}{If \code{TRUE}, the default, adds a small expansion factor to
 the limits to ensure that data and axes don't overlap. If \code{FALSE},
-limits are taken exactly from the data or \code{xlim}/\code{ylim}.}
+limits are taken exactly from the data or \code{xlim}/\code{ylim}. If
+a logical vector of length 4 (e.g.: \code{c(TRUE, FALSE, FALSE, TRUE)}),
+the expansion factor is selectively applied. The 4 elements will refer to the
+left, right, bottom and top edges of the plot in that order.}
 }
 \description{
 The representation of a portion of the earth, which is approximately spherical,


### PR DESCRIPTION
Modified the CoordCartesian function so that `coord_cartesian` can also accept a logical vector of length 4 for `expand` parameter. This is useful, especially in facet plots of bar graphs, where one would want to not expand the plot on the bottom side, and instead keep the bar anchored to 0. Also, this modification solves [this question from stackoverflow](https://stackoverflow.com/questions/27028825/ggplot2-force-y-axis-to-start-at-origin-and-float-y-axis-upper-limit).

An example:
`p <- ggplot(mtcars, aes(disp, wt)) + geom_point() +  geom_smooth()`
`print(p)`
![original](https://cloud.githubusercontent.com/assets/4915751/17431077/aa7fda02-5b15-11e6-942c-33185d30aea4.png)

`p + coord_cartesian(expand = c(T, F, F, T))`
![expand](https://cloud.githubusercontent.com/assets/4915751/17431081/af04346a-5b15-11e6-9908-1bbe12e018cc.png)

Notice that the expansion factor was applied to the left and top edges of the plot, but not to the other edges.

Since this is an addition, but not a modification of the existing functionality, I don't expect any backward compatibility problems.