### PR TITLE
Fixed issue where coord_map() fails when passed 'parameters' argument

### DIFF
--- a/R/coord-map.r
+++ b/R/coord-map.r
@@ -243,7 +243,7 @@ CoordMap <- ggproto("CoordMap", Coord,
 mproject <- function(coord, x, y, orientation) {
   suppressWarnings(mapproj::mapproject(x, y,
     projection = coord$projection,
-    parameters  = coord$params,
+    parameters  = unlist(coord$params),
     orientation = orientation
   ))
 }


### PR DESCRIPTION
This fails:

`
library(ggplot2)

nz <- map_data("nz")
nzmap <- ggplot(nz, aes(x = long, y = lat, group = group)) +
  geom_polygon(fill = "white", colour = "black")
nzmap + coord_map(projection = "lambert", parameters=c(12, 17.5))
`
Error in mapproj::mapproject(x, y, projection = coord$projection, parameters = coord$params,  : 
  (list) object cannot be coerced to type 'double'

I simply changed mproject so that unlist() is run on the 'parameters' argument before passing to mapproject()
