### PR TITLE
Cache palette and n in ScaleDiscrete

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,6 +62,9 @@
 
 * Class of aesthetic mapping is preserved when adding `aes()` objects. (#1624)
 
+* Only one warning is issued when asking for too many levels in 
+  `scale_discrete()` (#1674)
+
 # ggplot2 2.1.0
 
 ## New features

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -345,6 +345,8 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
 ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
   drop = TRUE,
   na.value = NA,
+  n.breaks.cache = NULL,
+  palette.cache = NULL,
 
   is_discrete = function() TRUE,
 
@@ -359,7 +361,14 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
 
   map = function(self, x, limits = self$get_limits()) {
     n <- sum(!is.na(limits))
-    pal <- self$palette(n)
+    if (!is.null(self$n.breaks.cache) && self$n.breaks.cache == n) {
+      pal <- self$palette.cache
+    } else {
+      if (!is.null(self$n.breaks.cache)) warning("Cached palette does not match requested", call. = FALSE)
+      pal <- self$palette(n)
+      self$palette.cache <- pal
+      self$n.breaks.cache <- n
+    }
 
     if (is.null(names(pal))) {
       pal_match <- pal[match(as.character(x), limits)]


### PR DESCRIPTION
This change saves the palette and the number of breaks in it and retrieves these values on subsequent calls, avoiding multiple warnings pertaining to the palette. Fixes #1674