### PR TITLE
Expand annotate aesthetics

### DIFF
--- a/R/annotation.r
+++ b/R/annotation.r
@@ -54,7 +54,7 @@ annotate <- function(geom, x = NULL, y = NULL, xmin = NULL, xmax = NULL,
     stop("Unequal parameter lengths: ", details, call. = FALSE)
   }
 
-  data <- data.frame(position)
+  data <- data.frame(aesthetics)
   layer(
     geom = geom,
     params = list(


### PR DESCRIPTION
Fixes #1609

Currently the annotate layer data is only based on positional ”aesthetics”. This PR includes all additional aesthetics given through … in the data. 