### PR TITLE
Added support for timezones in scale_datetime

### DIFF
--- a/R/scale-.r
+++ b/R/scale-.r
@@ -285,7 +285,13 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
     } else if (is.waive(self$labels)) {
       labels <- self$trans$format(breaks)
     } else if (is.function(self$labels)) {
+      # Client may supply a formatting function that returns another function,
+      # which uses context provided by the breaks themselves, which honor the
+      # input data format.
       labels <- self$labels(breaks)
+      if (is.function(labels)) {
+        labels <- labels(breaks)
+      }
     } else {
       labels <- self$labels
     }

--- a/R/scale-date.r
+++ b/R/scale-date.r
@@ -125,7 +125,14 @@ scale_datetime <- function(aesthetics, trans,
     minor_breaks <- date_breaks(date_minor_breaks)
   }
   if (!is.waive(date_labels)) {
-    labels <- date_format(date_labels)
+    # uses context from breaks to pass timezone
+    labels <- function(breaks) {
+      if ("POSIXt" %in% class(breaks)) {
+        tz <- attr(breaks, "tzone")
+        tz <- ifelse(is.null(tz), "UTC", tz)
+      } 
+      date_format(date_labels, tz=tz)
+    }
   }
 
   sc <- continuous_scale(aesthetics, name, identity,


### PR DESCRIPTION
Fixes #1718

This is a bit of a tricky issue: at the time the `date_format` function is passed as a label formatter in `scale_datetime`, the timezone is not known, as this is an attribute of the input data.

My solution is to define a special behavior when it comes to the `labels` argument passed to `scale_continuous`. If this argument is a function, it is evaluated once on `breaks`, as before. BUT, if it so happens that the return value of this evaluation is another function, then we evaluate this returned function on `breaks` one more time. The rationale for this is simple: there might be some formatting context that is only evident from the data, and this may have consequences on how formatting is done. For continuous scales timezone is a clear example, but the same logic could be used to implement some sort of locale-based formatting for discrete scales.

I have tested this fix using the following code:

```
library(ggplot2)
library(gridExtra)

df <- data.frame(
  time = as.POSIXct(as.Date("2010-01-01"), tz = "America/Chicago") + 1:10 * 3600,
  y = 1:10
)

p1 <- ggplot(df, aes(time, y)) + geom_point()
p2 <- ggplot(df, aes(time, y)) + geom_point() + scale_x_datetime(date_labels = "%H:%M %Z")
grid.arrange(p1, p2)
```

![image](https://cloud.githubusercontent.com/assets/3690985/17799560/7bf6b89c-6590-11e6-8c4b-8d4ac1e400fa.png)

P.S.: This is my first contribution to ggplot2, thanks for creating this amazing package!