### PR TITLE
Allow faceting by expressions in addition to column names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -219,4 +219,4 @@ Collate:
     'zxx.r'
     'zzz.r'
 VignetteBuilder: knitr
-RoxygenNote: 5.0.1.9000
+RoxygenNote: 5.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -219,4 +219,4 @@ Collate:
     'zxx.r'
     'zzz.r'
 VignetteBuilder: knitr
-RoxygenNote: 5.0.1
+RoxygenNote: 5.0.1.9000

--- a/R/facet-.r
+++ b/R/facet-.r
@@ -26,10 +26,12 @@ is.facet <- function(x) inherits(x, "facet")
 #
 # @param data a list of data frames (one for the plot and one for each
 #   layer)
-facet_train_layout <- function(facet, data)
+# @param env environment of the plot
+facet_train_layout <- function(facet, data, env)
   UseMethod("facet_train_layout")
 
-facet_map_layout <- function(facet, data, layout)
+# @param env environment of the plot
+facet_map_layout <- function(facet, data, layout, env)
   UseMethod("facet_map_layout")
 
 facet_render <- function(facet, panels_grob, coord, theme, geom_grobs)

--- a/R/facet-grid-.r
+++ b/R/facet-grid-.r
@@ -171,8 +171,8 @@ facet_grid <- function(facets, margins = FALSE, scales = "fixed", space = "fixed
 
 #' @export
 facet_train_layout.grid <- function(facet, data, env) {
-  layout <- layout_grid(data, env, facet$rows, facet$cols, facet$margins,
-    drop = facet$drop, as.table = facet$as.table)
+  layout <- layout_grid(data, facet$rows, facet$cols, facet$margins,
+    drop = facet$drop, as.table = facet$as.table, env)
 
   # Relax constraints, if necessary
   layout$SCALE_X <- if (facet$free$x) layout$COL else 1L
@@ -184,7 +184,7 @@ facet_train_layout.grid <- function(facet, data, env) {
 
 #' @export
 facet_map_layout.grid <- function(facet, data, layout, env) {
-  locate_grid(data, layout, env, facet$rows, facet$cols, facet$margins)
+  locate_grid(data, layout, facet$rows, facet$cols, facet$margins, env)
 }
 
 #' @export

--- a/R/facet-grid-.r
+++ b/R/facet-grid-.r
@@ -171,7 +171,7 @@ facet_grid <- function(facets, margins = FALSE, scales = "fixed", space = "fixed
 
 #' @export
 facet_train_layout.grid <- function(facet, data, env) {
-  layout <- layout_grid(data, facet$rows, facet$cols, facet$margins,
+  layout <- layout_grid(data, env, facet$rows, facet$cols, facet$margins,
     drop = facet$drop, as.table = facet$as.table)
 
   # Relax constraints, if necessary

--- a/R/facet-grid-.r
+++ b/R/facet-grid-.r
@@ -170,7 +170,7 @@ facet_grid <- function(facets, margins = FALSE, scales = "fixed", space = "fixed
 
 
 #' @export
-facet_train_layout.grid <- function(facet, data) {
+facet_train_layout.grid <- function(facet, data, env) {
   layout <- layout_grid(data, facet$rows, facet$cols, facet$margins,
     drop = facet$drop, as.table = facet$as.table)
 
@@ -183,8 +183,8 @@ facet_train_layout.grid <- function(facet, data) {
 
 
 #' @export
-facet_map_layout.grid <- function(facet, data, layout) {
-  locate_grid(data, layout, facet$rows, facet$cols, facet$margins)
+facet_map_layout.grid <- function(facet, data, layout, env) {
+  locate_grid(data, layout, env, facet$rows, facet$cols, facet$margins)
 }
 
 #' @export

--- a/R/facet-layout.r
+++ b/R/facet-layout.r
@@ -1,14 +1,14 @@
 # Layout panels in a 2d grid.
 #
 # @params data list of data frames, one for each layer
-# @params env envronment of the plot
 # @params rows variables that form the rows
 # @params cols variables that form the columns
+# @params env envronment to use when evaluating expressions
 # @return a data frame with columns \code{PANEL}, \code{ROW} and \code{COL},
 #   that match the facetting variable values up with their position in the
 #   grid
-layout_grid <- function(data, env, rows = NULL, cols = NULL, margins = NULL,
-                       drop = TRUE, as.table = TRUE) {
+layout_grid <- function(data, rows = NULL, cols = NULL, margins = NULL,
+                       drop = TRUE, as.table = TRUE, env = parent.frame()) {
   if (length(rows) == 0 && length(cols) == 0) return(layout_null())
   rows <- as.quoted(rows)
   cols <- as.quoted(cols)
@@ -43,10 +43,10 @@ layout_grid <- function(data, env, rows = NULL, cols = NULL, margins = NULL,
 # Layout out panels in a 1d ribbon.
 #
 # @params drop should missing combinations be excluded from the plot?
-# @params env environment of the plot
+# @params env environment to evaluate expressions
 # @keywords internal
-layout_wrap <- function(data, env, vars = NULL, nrow = NULL, ncol = NULL,
-                        as.table = TRUE, drop = TRUE, dir = "h") {
+layout_wrap <- function(data, vars = NULL, nrow = NULL, ncol = NULL, as.table = TRUE,
+                        drop = TRUE, dir = "h", env = parent.frame()) {
   vars <- as.quoted(vars)
   if (length(vars) == 0) return(layout_null())
 
@@ -115,6 +115,7 @@ layout_base <- function(data, env, vars = NULL, drop = TRUE) {
     if (drop) {
       new <- unique_combs(new)
     }
+
     base <- rbind(base, df.grid(old, new))
   }
 

--- a/R/facet-layout.r
+++ b/R/facet-layout.r
@@ -89,7 +89,7 @@ layout_base <- function(data, vars = NULL, drop = TRUE) {
   if (length(vars) == 0) return(data.frame())
 
   # For each layer, compute the facet values
-  values <- compact(plyr::llply(data, quoted_df, vars = vars))
+  values <- compact(plyr::llply(data, quoted_df, vars = vars, env = parent.env(environment())))
 
   # Form the base data frame which contains all combinations of facetting
   # variables that appear in the data
@@ -153,8 +153,8 @@ df.grid <- function(a, b) {
   ))
 }
 
-quoted_df <- function(data, vars) {
-  values <- plyr::eval.quoted(vars, data, emptyenv(), try = TRUE)
+quoted_df <- function(data, vars, env = emptyenv()) {
+  values <- plyr::eval.quoted(vars, data, env, try = TRUE)
   as.data.frame(compact(values), optional = TRUE, stringsAsFactors = FALSE)
 }
 

--- a/R/facet-layout.r
+++ b/R/facet-layout.r
@@ -1,23 +1,24 @@
 # Layout panels in a 2d grid.
 #
 # @params data list of data frames, one for each layer
+# @params env envronment of the plot
 # @params rows variables that form the rows
 # @params cols variables that form the columns
 # @return a data frame with columns \code{PANEL}, \code{ROW} and \code{COL},
 #   that match the facetting variable values up with their position in the
 #   grid
-layout_grid <- function(data, rows = NULL, cols = NULL, margins = NULL,
+layout_grid <- function(data, env, rows = NULL, cols = NULL, margins = NULL,
                        drop = TRUE, as.table = TRUE) {
   if (length(rows) == 0 && length(cols) == 0) return(layout_null())
   rows <- as.quoted(rows)
   cols <- as.quoted(cols)
 
-  base_rows <- layout_base(data, rows, drop = drop)
+  base_rows <- layout_base(data, env, rows, drop = drop)
   if (!as.table) {
     rev_order <- function(x) factor(x, levels = rev(ulevels(x)))
     base_rows[] <- lapply(base_rows, rev_order)
   }
-  base_cols <- layout_base(data, cols, drop = drop)
+  base_cols <- layout_base(data, env, cols, drop = drop)
   base <- df.grid(base_rows, base_cols)
 
   # Add margins
@@ -42,13 +43,14 @@ layout_grid <- function(data, rows = NULL, cols = NULL, margins = NULL,
 # Layout out panels in a 1d ribbon.
 #
 # @params drop should missing combinations be excluded from the plot?
+# @params env environment of the plot
 # @keywords internal
-layout_wrap <- function(data, vars = NULL, nrow = NULL, ncol = NULL,
+layout_wrap <- function(data, env, vars = NULL, nrow = NULL, ncol = NULL,
                         as.table = TRUE, drop = TRUE, dir = "h") {
   vars <- as.quoted(vars)
   if (length(vars) == 0) return(layout_null())
 
-  base <- plyr::unrowname(layout_base(data, vars, drop = drop))
+  base <- plyr::unrowname(layout_base(data, env, vars, drop = drop))
 
   id <- plyr::id(base, drop = TRUE)
   n <- attr(id, "n")
@@ -84,12 +86,13 @@ layout_null <- function() {
 # Other data frames in the list are ones that are added to layers.
 #
 # @params data list of data frames (one for each layer)
+# @params env environment of the plot
 # @keywords internal
-layout_base <- function(data, vars = NULL, drop = TRUE) {
+layout_base <- function(data, env, vars = NULL, drop = TRUE) {
   if (length(vars) == 0) return(data.frame())
 
   # For each layer, compute the facet values
-  values <- compact(plyr::llply(data, quoted_df, vars = vars, env = parent.env(environment())))
+  values <- compact(plyr::llply(data, quoted_df, vars = vars, env = env))
 
   # Form the base data frame which contains all combinations of facetting
   # variables that appear in the data

--- a/R/facet-locate.r
+++ b/R/facet-locate.r
@@ -7,7 +7,8 @@ NO_PANEL <- -1L
 # levels and for margins.
 #
 # @params data a data frame
-locate_grid <- function(data, panels, rows = NULL, cols = NULL, margins = FALSE) {
+# @params env environment of the plot
+locate_grid <- function(data, panels, env, rows = NULL, cols = NULL, margins = FALSE) {
   if (empty(data)) {
     return(cbind(data, PANEL = integer(0)))
   }
@@ -21,7 +22,7 @@ locate_grid <- function(data, panels, rows = NULL, cols = NULL, margins = FALSE)
     intersect(names(cols), names(data)))
   data <- reshape2::add_margins(data, margin_vars, margins)
 
-  facet_vals <- quoted_df(data, c(rows, cols), parent.frame())
+  facet_vals <- quoted_df(data, c(rows, cols), env)
 
   # If any facetting variables are missing, add them in by
   # duplicating the data
@@ -54,13 +55,14 @@ locate_grid <- function(data, panels, rows = NULL, cols = NULL, margins = FALSE)
   data[order(data$PANEL), , drop = FALSE]
 }
 
-locate_wrap <- function(data, panels, vars) {
+# @params env environment of the plot
+locate_wrap <- function(data, panels, env, vars) {
   if (empty(data)) {
     return(cbind(data, PANEL = integer(0)))
   }
   vars <- as.quoted(vars)
 
-  facet_vals <- quoted_df(data, vars, parent.frame())
+  facet_vals <- quoted_df(data, vars, env)
   facet_vals[] <- lapply(facet_vals[], as.factor)
 
   missing_facets <- setdiff(names(vars), names(facet_vals))

--- a/R/facet-locate.r
+++ b/R/facet-locate.r
@@ -21,7 +21,7 @@ locate_grid <- function(data, panels, rows = NULL, cols = NULL, margins = FALSE)
     intersect(names(cols), names(data)))
   data <- reshape2::add_margins(data, margin_vars, margins)
 
-  facet_vals <- quoted_df(data, c(rows, cols))
+  facet_vals <- quoted_df(data, c(rows, cols), parent.env(environment()))
 
   # If any facetting variables are missing, add them in by
   # duplicating the data
@@ -60,7 +60,7 @@ locate_wrap <- function(data, panels, vars) {
   }
   vars <- as.quoted(vars)
 
-  facet_vals <- quoted_df(data, vars)
+  facet_vals <- quoted_df(data, vars, parent.env(environment()))
   facet_vals[] <- lapply(facet_vals[], as.factor)
 
   missing_facets <- setdiff(names(vars), names(facet_vals))

--- a/R/facet-locate.r
+++ b/R/facet-locate.r
@@ -21,7 +21,7 @@ locate_grid <- function(data, panels, rows = NULL, cols = NULL, margins = FALSE)
     intersect(names(cols), names(data)))
   data <- reshape2::add_margins(data, margin_vars, margins)
 
-  facet_vals <- quoted_df(data, c(rows, cols), parent.env(environment()))
+  facet_vals <- quoted_df(data, c(rows, cols), parent.frame())
 
   # If any facetting variables are missing, add them in by
   # duplicating the data
@@ -60,7 +60,7 @@ locate_wrap <- function(data, panels, vars) {
   }
   vars <- as.quoted(vars)
 
-  facet_vals <- quoted_df(data, vars, parent.env(environment()))
+  facet_vals <- quoted_df(data, vars, parent.frame())
   facet_vals[] <- lapply(facet_vals[], as.factor)
 
   missing_facets <- setdiff(names(vars), names(facet_vals))

--- a/R/facet-locate.r
+++ b/R/facet-locate.r
@@ -8,7 +8,7 @@ NO_PANEL <- -1L
 #
 # @params data a data frame
 # @params env environment of the plot
-locate_grid <- function(data, panels, env, rows = NULL, cols = NULL, margins = FALSE) {
+locate_grid <- function(data, panels, rows = NULL, cols = NULL, margins = FALSE, env = parent_frame()) {
   if (empty(data)) {
     return(cbind(data, PANEL = integer(0)))
   }
@@ -56,7 +56,7 @@ locate_grid <- function(data, panels, env, rows = NULL, cols = NULL, margins = F
 }
 
 # @params env environment of the plot
-locate_wrap <- function(data, panels, env, vars) {
+locate_wrap <- function(data, panels, vars, env = parent_frame()) {
   if (empty(data)) {
     return(cbind(data, PANEL = integer(0)))
   }

--- a/R/facet-null.r
+++ b/R/facet-null.r
@@ -11,14 +11,14 @@ facet_null <- function(shrink = TRUE) {
 }
 
 #' @export
-facet_train_layout.null <- function(facet, data) {
+facet_train_layout.null <- function(facet, data, env) {
   data.frame(
     PANEL = 1L, ROW = 1L, COL = 1L,
     SCALE_X = 1L, SCALE_Y = 1L)
 }
 
 #' @export
-facet_map_layout.null <- function(facet, data, layout) {
+facet_map_layout.null <- function(facet, data, layout, env) {
   # Need the is.waive check for special case where no data, but aesthetics
   # are mapped to vectors
   if (is.waive(data) || empty(data))

--- a/R/facet-wrap.r
+++ b/R/facet-wrap.r
@@ -110,8 +110,8 @@ facet_wrap <- function(facets, nrow = NULL, ncol = NULL, scales = "fixed",
 
 #' @export
 facet_train_layout.wrap <- function(facet, data, env) {
-  panels <- layout_wrap(data, env, facet$facets, facet$nrow, facet$ncol,
-     facet$as.table, facet$drop, facet$dir)
+  panels <- layout_wrap(data, facet$facets, facet$nrow, facet$ncol,
+     facet$as.table, facet$drop, facet$dir, env)
 
   n <- nrow(panels)
   nrow <- max(panels$ROW)
@@ -129,7 +129,7 @@ facet_train_layout.wrap <- function(facet, data, env) {
 
 #' @export
 facet_map_layout.wrap <- function(facet, data, layout, env) {
-  locate_wrap(data, layout, env, facet$facets)
+  locate_wrap(data, layout, facet$facets, env)
 }
 
 # How to think about facet wrap:

--- a/R/facet-wrap.r
+++ b/R/facet-wrap.r
@@ -109,8 +109,8 @@ facet_wrap <- function(facets, nrow = NULL, ncol = NULL, scales = "fixed",
 }
 
 #' @export
-facet_train_layout.wrap <- function(facet, data) {
-  panels <- layout_wrap(data, facet$facets, facet$nrow, facet$ncol,
+facet_train_layout.wrap <- function(facet, data, env) {
+  panels <- layout_wrap(data, env, facet$facets, facet$nrow, facet$ncol,
      facet$as.table, facet$drop, facet$dir)
 
   n <- nrow(panels)
@@ -128,8 +128,8 @@ facet_train_layout.wrap <- function(facet, data) {
 }
 
 #' @export
-facet_map_layout.wrap <- function(facet, data, layout) {
-  locate_wrap(data, layout, facet$facets)
+facet_map_layout.wrap <- function(facet, data, layout, env) {
+  locate_wrap(data, layout, env, facet$facets)
 }
 
 # How to think about facet wrap:

--- a/R/panel.r
+++ b/R/panel.r
@@ -25,9 +25,10 @@ new_panel <- function() {
 # @param the facetting specification
 # @param data a list of data frames (one for each layer), and one for the plot
 # @param plot_data the default data frame
+# @param env environment of the plot
 # @return an updated panel object
-train_layout <- function(panel, facet, data, plot_data) {
-  layout <- facet_train_layout(facet, c(list(plot_data), data))
+train_layout <- function(panel, facet, data, plot_data, env) {
+  layout <- facet_train_layout(facet, c(list(plot_data), data), env)
   panel$layout <- layout
   panel$shrink <- facet$shrink
 
@@ -45,9 +46,10 @@ train_layout <- function(panel, facet, data, plot_data) {
 # @param panel a trained panel object
 # @param the facetting specification
 # @param data list of data frames (one for each layer)
-map_layout <- function(panel, facet, data) {
+# @param env environment of the plot
+map_layout <- function(panel, facet, data, env) {
   lapply(data, function(data) {
-    facet_map_layout(facet, data, panel$layout)
+    facet_map_layout(facet, data, panel$layout, env)
   })
 }
 

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -38,8 +38,8 @@ ggplot_build <- function(plot) {
   # variables, and add on a PANEL variable to data
 
   panel <- new_panel()
-  panel <- train_layout(panel, plot$facet, layer_data, plot$data)
-  data <- map_layout(panel, plot$facet, layer_data)
+  panel <- train_layout(panel, plot$facet, layer_data, plot$data, plot$plot_env)
+  data <- map_layout(panel, plot$facet, layer_data, plot$plot_env)
 
   # Compute aesthetics to produce data with generalised variable names
   data <- by_layer(function(l, d) l$compute_aesthetics(d, plot))

--- a/tests/testthat/test-facet-.r
+++ b/tests/testthat/test-facet-.r
@@ -53,3 +53,20 @@ test_that("shrink parameter affects scaling", {
   r3 <- pranges(l3)
   expect_equal(r3$y[[1]], c(1, 3))
 })
+
+test_that("scoping of facet expression evaluation works", {
+  df <- data.frame(x = 1:5, y = 1:5, z = 1)
+
+  f <- function() {
+    g <- function(x) x + 2
+  
+    ggplot(df, aes(x, y)) +
+      geom_point() + 
+      facet_grid(. ~ g(x))
+  }
+
+  d <- ggplot_build(f())$data[[1]]
+
+  # we should get 5 panels
+  expect_equal(length(unique(d$PANEL)), 5)
+})

--- a/tests/testthat/test-facet-layout.r
+++ b/tests/testthat/test-facet-layout.r
@@ -6,20 +6,20 @@ c <- data.frame(b = 3)
 empty <- data.frame()
 
 test_that("all: no rows and cols gives null layout", {
-  expect_equal(layout_grid(list(a), NULL), layout_null())
-  expect_equal(layout_wrap(list(a), NULL), layout_null())
+  expect_equal(layout_grid(list(a), env = NULL), layout_null())
+  expect_equal(layout_wrap(list(a), env = NULL), layout_null())
 })
 
 test_that("grid: single row and single col equivalent", {
-  row <- layout_grid(list(a), NULL, rows = "a")
-  col <- layout_grid(list(a), NULL, cols = "a")
+  row <- layout_grid(list(a), rows = "a", env = NULL)
+  col <- layout_grid(list(a), cols = "a", env = NULL)
 
   expect_equal(row$ROW, 1:2)
   expect_equal(row$ROW, col$COL)
   expect_equal(row[c("PANEL", "a")], col[c("PANEL", "a")])
 
-  row <- layout_grid(list(a, b), NULL, rows = "a")
-  col <- layout_grid(list(a, b), NULL, cols = "a")
+  row <- layout_grid(list(a, b), rows = "a", env = NULL)
+  col <- layout_grid(list(a, b), cols = "a", env = NULL)
 
   expect_equal(row$ROW, 1:3)
   expect_equal(row$ROW, col$COL)
@@ -28,62 +28,62 @@ test_that("grid: single row and single col equivalent", {
 
 test_that("grid: includes all combinations", {
   d <- data.frame(a = c(1, 2), b = c(2, 1))
-  all <- layout_grid(list(d), NULL, rows = "a", cols = "b")
+  all <- layout_grid(list(d), rows = "a", cols = "b", env = NULL)
 
   expect_equal(nrow(all), 4)
 })
 
 test_that("wrap and grid equivalent for 1d data", {
-  rowg <- layout_grid(list(a), NULL, rows = "a")
-  roww <- layout_wrap(list(a), NULL, "a", ncol = 1)
+  rowg <- layout_grid(list(a), rows = "a", env = NULL)
+  roww <- layout_wrap(list(a), "a", ncol = 1, env = NULL)
   expect_equal(roww, rowg)
 
-  colg <- layout_grid(list(a), NULL, cols = "a")
-  colw <- layout_wrap(list(a), NULL, "a", nrow = 1)
+  colg <- layout_grid(list(a), cols = "a", env = NULL)
+  colw <- layout_wrap(list(a), "a", nrow = 1, env = NULL)
   expect_equal(colw, colg)
 })
 
 test_that("grid: crossed rows/cols create no more combinations than necessary", {
-  one <- layout_grid(list(a), NULL, "a", "b")
+  one <- layout_grid(list(a), "a", "b", env = NULL)
   expect_equal(nrow(one), 4)
 
-  one_a <- layout_grid(list(a, empty), NULL, "a", "b")
+  one_a <- layout_grid(list(a, empty), "a", "b", env = NULL)
   expect_equal(nrow(one_a), 4)
 
-  two <- layout_grid(list(a, b), NULL, "a", "b")
+  two <- layout_grid(list(a, b), "a", "b", env = NULL)
   expect_equal(nrow(two), 4 + 2)
 
-  three <- layout_grid(list(a, b, c), NULL, "a", "b")
+  three <- layout_grid(list(a, b, c), "a", "b", env = NULL)
   expect_equal(nrow(three), 9)
 
-  four <- layout_grid(list(b, c), NULL, "a", "b")
+  four <- layout_grid(list(b, c), "a", "b", env = NULL)
   expect_equal(nrow(four), 1)
 })
 
 test_that("grid: nested rows/cols create no more combinations than necessary", {
-  one <- layout_grid(list(mpg), NULL, c("drv", "cyl"))
+  one <- layout_grid(list(mpg), c("drv", "cyl"), env = NULL)
   expect_equal(one$PANEL, factor(1:9))
   expect_equal(one$ROW, 1:9)
 })
 
 test_that("grid: margins add correct combinations", {
-  one <- layout_grid(list(a), NULL, "a", "b", margins = TRUE)
+  one <- layout_grid(list(a), "a", "b", margins = TRUE, env = NULL)
   expect_equal(nrow(one), 4 + 2 + 2 + 1)
 })
 
 test_that("wrap: as.table reverses rows", {
-  one <- layout_wrap(list(a), NULL, "a", ncol = 1, as.table = FALSE)
+  one <- layout_wrap(list(a), "a", ncol = 1, as.table = FALSE, env = NULL)
   expect_equal(one$ROW, c(2, 1))
 
-  two <- layout_wrap(list(a), NULL, "a", nrow = 1, as.table = FALSE)
+  two <- layout_wrap(list(a), "a", nrow = 1, as.table = FALSE, env = NULL)
   expect_equal(two$ROW, c(1, 1))
 })
 
 test_that("grid: as.table reverses rows", {
-  one <- layout_grid(list(a), NULL, "a", as.table = FALSE)
+  one <- layout_grid(list(a), "a", as.table = FALSE, env = NULL)
   expect_equal(as.character(one$a), c("2", "1"))
 
-  two <- layout_grid(list(a), NULL, "a", as.table = TRUE)
+  two <- layout_grid(list(a), "a", as.table = TRUE, env = NULL)
   expect_equal(as.character(two$a), c("1", "2"))
 })
 
@@ -95,26 +95,26 @@ a2 <- data.frame(
 )
 
 test_that("layout_wrap: drop = FALSE preserves unused levels", {
-  wrap_a <- layout_wrap(list(a2), NULL, "a", drop = FALSE)
+  wrap_a <- layout_wrap(list(a2), "a", drop = FALSE, env = NULL)
   expect_equal(nrow(wrap_a), 4)
   expect_equal(as.character(wrap_a$a), as.character(1:4))
 
-  wrap_b <- layout_wrap(list(a2), NULL, "b", drop = FALSE)
+  wrap_b <- layout_wrap(list(a2), "b", drop = FALSE, env = NULL)
   expect_equal(nrow(wrap_b), 4)
   expect_equal(as.character(wrap_b$b), as.character(4:1))
 
 })
 
 test_that("layout_grid: drop = FALSE preserves unused levels", {
-  grid_a <- layout_grid(list(a2), NULL, "a", drop = FALSE)
+  grid_a <- layout_grid(list(a2), "a", drop = FALSE, env = NULL)
   expect_equal(nrow(grid_a), 4)
   expect_equal(as.character(grid_a$a), as.character(1:4))
 
-  grid_b <- layout_grid(list(a2), NULL, "b", drop = FALSE)
+  grid_b <- layout_grid(list(a2), "b", drop = FALSE, env = NULL)
   expect_equal(nrow(grid_b), 4)
   expect_equal(as.character(grid_b$b), as.character(4:1))
 
-  grid_ab <- layout_grid(list(a2), NULL, "a", "b", drop = FALSE)
+  grid_ab <- layout_grid(list(a2), "a", "b", drop = FALSE, env = NULL)
   expect_equal(nrow(grid_ab), 16)
   expect_equal(as.character(grid_ab$a), as.character(rep(1:4, each = 4)))
   expect_equal(as.character(grid_ab$b), as.character(rep(4:1, 4)))
@@ -130,12 +130,12 @@ a3 <- data.frame(
 )
 
 test_that("missing values get a panel", {
-  wrap_a <- layout_wrap(list(a3), NULL, "a")
-  wrap_b <- layout_wrap(list(a3), NULL, "b")
-  wrap_c <- layout_wrap(list(a3), NULL, "c")
-  grid_a <- layout_grid(list(a3), NULL, "a")
-  grid_b <- layout_grid(list(a3), NULL, "b")
-  grid_c <- layout_grid(list(a3), NULL, "c")
+  wrap_a <- layout_wrap(list(a3), "a", env = NULL)
+  wrap_b <- layout_wrap(list(a3), "b", env = NULL)
+  wrap_c <- layout_wrap(list(a3), "c", env = NULL)
+  grid_a <- layout_grid(list(a3), "a", env = NULL)
+  grid_b <- layout_grid(list(a3), "b", env = NULL)
+  grid_c <- layout_grid(list(a3), "c", env = NULL)
 
   expect_equal(nrow(wrap_a), 4)
   expect_equal(nrow(wrap_b), 4)

--- a/tests/testthat/test-facet-layout.r
+++ b/tests/testthat/test-facet-layout.r
@@ -6,20 +6,20 @@ c <- data.frame(b = 3)
 empty <- data.frame()
 
 test_that("all: no rows and cols gives null layout", {
-  expect_equal(layout_grid(list(a)), layout_null())
-  expect_equal(layout_wrap(list(a)), layout_null())
+  expect_equal(layout_grid(list(a), NULL), layout_null())
+  expect_equal(layout_wrap(list(a), NULL), layout_null())
 })
 
 test_that("grid: single row and single col equivalent", {
-  row <- layout_grid(list(a), rows = "a")
-  col <- layout_grid(list(a), cols = "a")
+  row <- layout_grid(list(a), NULL, rows = "a")
+  col <- layout_grid(list(a), NULL, cols = "a")
 
   expect_equal(row$ROW, 1:2)
   expect_equal(row$ROW, col$COL)
   expect_equal(row[c("PANEL", "a")], col[c("PANEL", "a")])
 
-  row <- layout_grid(list(a, b), rows = "a")
-  col <- layout_grid(list(a, b), cols = "a")
+  row <- layout_grid(list(a, b), NULL, rows = "a")
+  col <- layout_grid(list(a, b), NULL, cols = "a")
 
   expect_equal(row$ROW, 1:3)
   expect_equal(row$ROW, col$COL)
@@ -28,62 +28,62 @@ test_that("grid: single row and single col equivalent", {
 
 test_that("grid: includes all combinations", {
   d <- data.frame(a = c(1, 2), b = c(2, 1))
-  all <- layout_grid(list(d), rows = "a", cols = "b")
+  all <- layout_grid(list(d), NULL, rows = "a", cols = "b")
 
   expect_equal(nrow(all), 4)
 })
 
 test_that("wrap and grid equivalent for 1d data", {
-  rowg <- layout_grid(list(a), rows = "a")
-  roww <- layout_wrap(list(a), "a", ncol = 1)
+  rowg <- layout_grid(list(a), NULL, rows = "a")
+  roww <- layout_wrap(list(a), NULL, "a", ncol = 1)
   expect_equal(roww, rowg)
 
-  colg <- layout_grid(list(a), cols = "a")
-  colw <- layout_wrap(list(a), "a", nrow = 1)
+  colg <- layout_grid(list(a), NULL, cols = "a")
+  colw <- layout_wrap(list(a), NULL, "a", nrow = 1)
   expect_equal(colw, colg)
 })
 
 test_that("grid: crossed rows/cols create no more combinations than necessary", {
-  one <- layout_grid(list(a), "a", "b")
+  one <- layout_grid(list(a), NULL, "a", "b")
   expect_equal(nrow(one), 4)
 
-  one_a <- layout_grid(list(a, empty), "a", "b")
+  one_a <- layout_grid(list(a, empty), NULL, "a", "b")
   expect_equal(nrow(one_a), 4)
 
-  two <- layout_grid(list(a, b), "a", "b")
+  two <- layout_grid(list(a, b), NULL, "a", "b")
   expect_equal(nrow(two), 4 + 2)
 
-  three <- layout_grid(list(a, b, c), "a", "b")
+  three <- layout_grid(list(a, b, c), NULL, "a", "b")
   expect_equal(nrow(three), 9)
 
-  four <- layout_grid(list(b, c), "a", "b")
+  four <- layout_grid(list(b, c), NULL, "a", "b")
   expect_equal(nrow(four), 1)
 })
 
 test_that("grid: nested rows/cols create no more combinations than necessary", {
-  one <- layout_grid(list(mpg), c("drv", "cyl"))
+  one <- layout_grid(list(mpg), NULL, c("drv", "cyl"))
   expect_equal(one$PANEL, factor(1:9))
   expect_equal(one$ROW, 1:9)
 })
 
 test_that("grid: margins add correct combinations", {
-  one <- layout_grid(list(a), "a", "b", margins = TRUE)
+  one <- layout_grid(list(a), NULL, "a", "b", margins = TRUE)
   expect_equal(nrow(one), 4 + 2 + 2 + 1)
 })
 
 test_that("wrap: as.table reverses rows", {
-  one <- layout_wrap(list(a), "a", ncol = 1, as.table = FALSE)
+  one <- layout_wrap(list(a), NULL, "a", ncol = 1, as.table = FALSE)
   expect_equal(one$ROW, c(2, 1))
 
-  two <- layout_wrap(list(a), "a", nrow = 1, as.table = FALSE)
+  two <- layout_wrap(list(a), NULL, "a", nrow = 1, as.table = FALSE)
   expect_equal(two$ROW, c(1, 1))
 })
 
 test_that("grid: as.table reverses rows", {
-  one <- layout_grid(list(a), "a", as.table = FALSE)
+  one <- layout_grid(list(a), NULL, "a", as.table = FALSE)
   expect_equal(as.character(one$a), c("2", "1"))
 
-  two <- layout_grid(list(a), "a", as.table = TRUE)
+  two <- layout_grid(list(a), NULL, "a", as.table = TRUE)
   expect_equal(as.character(two$a), c("1", "2"))
 })
 
@@ -95,26 +95,26 @@ a2 <- data.frame(
 )
 
 test_that("layout_wrap: drop = FALSE preserves unused levels", {
-  wrap_a <- layout_wrap(list(a2), "a", drop = FALSE)
+  wrap_a <- layout_wrap(list(a2), NULL, "a", drop = FALSE)
   expect_equal(nrow(wrap_a), 4)
   expect_equal(as.character(wrap_a$a), as.character(1:4))
 
-  wrap_b <- layout_wrap(list(a2), "b", drop = FALSE)
+  wrap_b <- layout_wrap(list(a2), NULL, "b", drop = FALSE)
   expect_equal(nrow(wrap_b), 4)
   expect_equal(as.character(wrap_b$b), as.character(4:1))
 
 })
 
 test_that("layout_grid: drop = FALSE preserves unused levels", {
-  grid_a <- layout_grid(list(a2), "a", drop = FALSE)
+  grid_a <- layout_grid(list(a2), NULL, "a", drop = FALSE)
   expect_equal(nrow(grid_a), 4)
   expect_equal(as.character(grid_a$a), as.character(1:4))
 
-  grid_b <- layout_grid(list(a2), "b", drop = FALSE)
+  grid_b <- layout_grid(list(a2), NULL, "b", drop = FALSE)
   expect_equal(nrow(grid_b), 4)
   expect_equal(as.character(grid_b$b), as.character(4:1))
 
-  grid_ab <- layout_grid(list(a2), "a", "b", drop = FALSE)
+  grid_ab <- layout_grid(list(a2), NULL, "a", "b", drop = FALSE)
   expect_equal(nrow(grid_ab), 16)
   expect_equal(as.character(grid_ab$a), as.character(rep(1:4, each = 4)))
   expect_equal(as.character(grid_ab$b), as.character(rep(4:1, 4)))
@@ -130,12 +130,12 @@ a3 <- data.frame(
 )
 
 test_that("missing values get a panel", {
-  wrap_a <- layout_wrap(list(a3), "a")
-  wrap_b <- layout_wrap(list(a3), "b")
-  wrap_c <- layout_wrap(list(a3), "c")
-  grid_a <- layout_grid(list(a3), "a")
-  grid_b <- layout_grid(list(a3), "b")
-  grid_c <- layout_grid(list(a3), "c")
+  wrap_a <- layout_wrap(list(a3), NULL, "a")
+  wrap_b <- layout_wrap(list(a3), NULL, "b")
+  wrap_c <- layout_wrap(list(a3), NULL, "c")
+  grid_a <- layout_grid(list(a3), NULL, "a")
+  grid_b <- layout_grid(list(a3), NULL, "b")
+  grid_c <- layout_grid(list(a3), NULL, "c")
 
   expect_equal(nrow(wrap_a), 4)
   expect_equal(nrow(wrap_b), 4)

--- a/tests/testthat/test-facet-locate.r
+++ b/tests/testthat/test-facet-locate.r
@@ -7,8 +7,8 @@ df_c <- unique(data.frame(c = 1))
 
 
 test_that("two col cases with no missings adds single extra column", {
-  vscyl <- layout_grid(list(mtcars), NULL, "cyl", "vs")
-  loc <- locate_grid(mtcars, vscyl, NULL, "cyl", "vs")
+  vscyl <- layout_grid(list(mtcars), "cyl", "vs", env = NULL)
+  loc <- locate_grid(mtcars, vscyl, "cyl", "vs", env = NULL)
 
   expect_equal(nrow(loc), nrow(mtcars))
   expect_equal(ncol(loc), ncol(mtcars) + 1)
@@ -19,42 +19,42 @@ test_that("two col cases with no missings adds single extra column", {
 })
 
 test_that("margins add extra data", {
-  panel <- layout_grid(list(df), NULL, "a", "b", margins = "b")
-  loc <- locate_grid(df, panel, NULL, "a", "b", margins = "b")
+  panel <- layout_grid(list(df), "a", "b", margins = "b", env = NULL)
+  loc <- locate_grid(df, panel, "a", "b", margins = "b", env = NULL)
 
   expect_equal(nrow(loc), nrow(df) * 2)
 })
 
 
 test_that("grid: missing facet columns are duplicated", {
-  panel <- layout_grid(list(df), NULL, "a", "b")
+  panel <- layout_grid(list(df), "a", "b", env = NULL)
 
-  loc_a <- locate_grid(df_a, panel, NULL, "a", "b")
+  loc_a <- locate_grid(df_a, panel, "a", "b", env = NULL)
   expect_equal(nrow(loc_a), 4)
   expect_equal(loc_a$PANEL, factor(1:4))
 
-  loc_b <- locate_grid(df_b, panel, NULL, "a", "b")
+  loc_b <- locate_grid(df_b, panel, "a", "b", env = NULL)
   expect_equal(nrow(loc_b), 4)
   expect_equal(loc_b$PANEL, factor(1:4))
 
-  loc_c <- locate_grid(df_c, panel, NULL, "a", "b")
+  loc_c <- locate_grid(df_c, panel, "a", "b", env = NULL)
   expect_equal(nrow(loc_c), 4)
   expect_equal(loc_c$PANEL, factor(1:4))
 })
 
 test_that("wrap: missing facet columns are duplicated", {
-  panel <- layout_wrap(list(df), NULL, c("a", "b"), ncol = 1)
+  panel <- layout_wrap(list(df), c("a", "b"), ncol = 1, env = NULL)
 
-  loc_a <- locate_wrap(df_a, panel, NULL, c("a", "b"))
+  loc_a <- locate_wrap(df_a, panel, c("a", "b"), NULL)
   expect_equal(nrow(loc_a), 4)
   expect_equal(loc_a$PANEL, factor(1:4))
   expect_equal(loc_a$a, c(1, 1, 2, 2))
 
-  loc_b <- locate_wrap(df_b, panel, NULL, c("a", "b"))
+  loc_b <- locate_wrap(df_b, panel, c("a", "b"), NULL)
   expect_equal(nrow(loc_b), 4)
   expect_equal(loc_b$PANEL, factor(1:4))
 
-  loc_c <- locate_wrap(df_c, panel, NULL, c("a", "b"))
+  loc_c <- locate_wrap(df_c, panel, c("a", "b"), NULL)
   expect_equal(nrow(loc_c), 4)
   expect_equal(loc_c$PANEL, factor(1:4))
 
@@ -69,23 +69,23 @@ a3 <- data.frame(
 )
 
 test_that("wrap: missing values located correctly", {
-  panel_b <- layout_wrap(list(a3), NULL, "b", ncol = 1)
-  loc_b <- locate_wrap(data.frame(b = NA), panel_b, NULL, "b")
+  panel_b <- layout_wrap(list(a3), "b", ncol = 1, env = NULL)
+  loc_b <- locate_wrap(data.frame(b = NA), panel_b, "b", NULL)
   expect_equal(as.character(loc_b$PANEL), "4")
 
-  panel_c <- layout_wrap(list(a3), NULL, "c", ncol = 1)
-  loc_c <- locate_wrap(data.frame(c = NA), panel_c, NULL, "c")
+  panel_c <- layout_wrap(list(a3), "c", ncol = 1, env = NULL)
+  loc_c <- locate_wrap(data.frame(c = NA), panel_c, "c", NULL)
   expect_equal(as.character(loc_c$PANEL), "4")
 
 })
 
 test_that("grid: missing values located correctly", {
-  panel_b <- layout_grid(list(a3), NULL, "b")
-  loc_b <- locate_grid(data.frame(b = NA), panel_b, NULL, "b")
+  panel_b <- layout_grid(list(a3), "b", env = NULL)
+  loc_b <- locate_grid(data.frame(b = NA), panel_b, "b", env = NULL)
   expect_equal(as.character(loc_b$PANEL), "4")
 
-  panel_c <- layout_grid(list(a3), NULL, "c")
-  loc_c <- locate_grid(data.frame(c = NA), panel_c, NULL, "c")
+  panel_c <- layout_grid(list(a3), "c", env = NULL)
+  loc_c <- locate_grid(data.frame(c = NA), panel_c, "c", env = NULL)
   expect_equal(as.character(loc_c$PANEL), "4")
 })
 

--- a/tests/testthat/test-facet-locate.r
+++ b/tests/testthat/test-facet-locate.r
@@ -7,8 +7,8 @@ df_c <- unique(data.frame(c = 1))
 
 
 test_that("two col cases with no missings adds single extra column", {
-  vscyl <- layout_grid(list(mtcars), "cyl", "vs")
-  loc <- locate_grid(mtcars, vscyl, "cyl", "vs")
+  vscyl <- layout_grid(list(mtcars), NULL, "cyl", "vs")
+  loc <- locate_grid(mtcars, vscyl, NULL, "cyl", "vs")
 
   expect_equal(nrow(loc), nrow(mtcars))
   expect_equal(ncol(loc), ncol(mtcars) + 1)
@@ -19,42 +19,42 @@ test_that("two col cases with no missings adds single extra column", {
 })
 
 test_that("margins add extra data", {
-  panel <- layout_grid(list(df), "a", "b", margins = "b")
-  loc <- locate_grid(df, panel, "a", "b", margins = "b")
+  panel <- layout_grid(list(df), NULL, "a", "b", margins = "b")
+  loc <- locate_grid(df, panel, NULL, "a", "b", margins = "b")
 
   expect_equal(nrow(loc), nrow(df) * 2)
 })
 
 
 test_that("grid: missing facet columns are duplicated", {
-  panel <- layout_grid(list(df), "a", "b")
+  panel <- layout_grid(list(df), NULL, "a", "b")
 
-  loc_a <- locate_grid(df_a, panel, "a", "b")
+  loc_a <- locate_grid(df_a, panel, NULL, "a", "b")
   expect_equal(nrow(loc_a), 4)
   expect_equal(loc_a$PANEL, factor(1:4))
 
-  loc_b <- locate_grid(df_b, panel, "a", "b")
+  loc_b <- locate_grid(df_b, panel, NULL, "a", "b")
   expect_equal(nrow(loc_b), 4)
   expect_equal(loc_b$PANEL, factor(1:4))
 
-  loc_c <- locate_grid(df_c, panel, "a", "b")
+  loc_c <- locate_grid(df_c, panel, NULL, "a", "b")
   expect_equal(nrow(loc_c), 4)
   expect_equal(loc_c$PANEL, factor(1:4))
 })
 
 test_that("wrap: missing facet columns are duplicated", {
-  panel <- layout_wrap(list(df), c("a", "b"), ncol = 1)
+  panel <- layout_wrap(list(df), NULL, c("a", "b"), ncol = 1)
 
-  loc_a <- locate_wrap(df_a, panel, c("a", "b"))
+  loc_a <- locate_wrap(df_a, panel, NULL, c("a", "b"))
   expect_equal(nrow(loc_a), 4)
   expect_equal(loc_a$PANEL, factor(1:4))
   expect_equal(loc_a$a, c(1, 1, 2, 2))
 
-  loc_b <- locate_wrap(df_b, panel, c("a", "b"))
+  loc_b <- locate_wrap(df_b, panel, NULL, c("a", "b"))
   expect_equal(nrow(loc_b), 4)
   expect_equal(loc_b$PANEL, factor(1:4))
 
-  loc_c <- locate_wrap(df_c, panel, c("a", "b"))
+  loc_c <- locate_wrap(df_c, panel, NULL, c("a", "b"))
   expect_equal(nrow(loc_c), 4)
   expect_equal(loc_c$PANEL, factor(1:4))
 
@@ -69,23 +69,23 @@ a3 <- data.frame(
 )
 
 test_that("wrap: missing values located correctly", {
-  panel_b <- layout_wrap(list(a3), "b", ncol = 1)
-  loc_b <- locate_wrap(data.frame(b = NA), panel_b, "b")
+  panel_b <- layout_wrap(list(a3), NULL, "b", ncol = 1)
+  loc_b <- locate_wrap(data.frame(b = NA), panel_b, NULL, "b")
   expect_equal(as.character(loc_b$PANEL), "4")
 
-  panel_c <- layout_wrap(list(a3), "c", ncol = 1)
-  loc_c <- locate_wrap(data.frame(c = NA), panel_c, "c")
+  panel_c <- layout_wrap(list(a3), NULL, "c", ncol = 1)
+  loc_c <- locate_wrap(data.frame(c = NA), panel_c, NULL, "c")
   expect_equal(as.character(loc_c$PANEL), "4")
 
 })
 
 test_that("grid: missing values located correctly", {
-  panel_b <- layout_grid(list(a3), "b")
-  loc_b <- locate_grid(data.frame(b = NA), panel_b, "b")
+  panel_b <- layout_grid(list(a3), NULL, "b")
+  loc_b <- locate_grid(data.frame(b = NA), panel_b, NULL, "b")
   expect_equal(as.character(loc_b$PANEL), "4")
 
-  panel_c <- layout_grid(list(a3), "c")
-  loc_c <- locate_grid(data.frame(c = NA), panel_c, "c")
+  panel_c <- layout_grid(list(a3), NULL, "c")
+  loc_c <- locate_grid(data.frame(c = NA), panel_c, NULL, "c")
   expect_equal(as.character(loc_c$PANEL), "4")
 })
 


### PR DESCRIPTION
@hadley I made some simple modifications to the environments that are passed to `quoted_df` that seemed to make expressions work using `I().` I haven't done any of the documenting because I'd like you to have a look first and see what I have overlooked (can't believe it would be this easy...).

Example: `ggplot(mtcars) + stat_bin(aes(mpg)) + facet_grid(I(gear+1) ~ I(2*carb))`