### PR TITLE
Add explicit 'parameters' arg to coord_map() in response to PR #1699

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -200,6 +200,9 @@
 * Fixed a compatibility issue with `ggproto` and R versions prior to 3.1.2.
   (#1444)
 
+* Fixed issue where `coord_map()` fails when given an explicit `parameters`
+  argument (@tdmcarthur, #1729)
+
 # ggplot2 2.0.0
 
 ## Major changes

--- a/R/coord-map.r
+++ b/R/coord-map.r
@@ -21,9 +21,12 @@
 #' @export
 #' @param projection projection to use, see
 #'    \code{\link[mapproj]{mapproject}} for list
-#' @param ... other arguments passed on to mapproject. Ignored if the \code{parameters} argument is present.
-#' @param parameters optional numeric vector of parameters for use with the projection argument. This argument is optional only in the sense that certain projections do not require additional parameters. Passed to
-#'   \code{\link[mapproj]{mapproject}}
+#' @param ... other arguments passed on to \code{\link[mapproj]{mapproject}}.
+#' Ignored if the \code{parameters} argument is present.
+#' @param parameters optional numeric vector of parameters for use
+#' with the projection argument. This argument is optional only in
+#' the sense that certain projections do not require additional
+#' parameters. Passed to \code{\link[mapproj]{mapproject}}.
 #' @param orientation projection orientation, which defaults to
 #'  \code{c(90, 0, mean(range(x)))}.  This is not optimal for many
 #'  projections, so you will have to supply your own. See

--- a/R/coord-map.r
+++ b/R/coord-map.r
@@ -21,7 +21,7 @@
 #' @export
 #' @param projection projection to use, see
 #'    \code{\link[mapproj]{mapproject}} for list
-#' @param ... other arguments passed on to
+#' @param parameters optional numeric vector of parameters for use with the projection argument. This argument is optional only in the sense that certain projections do not require additional parameters. Passed to
 #'   \code{\link[mapproj]{mapproject}}
 #' @param orientation projection orientation, which defaults to
 #'  \code{c(90, 0, mean(range(x)))}.  This is not optimal for many
@@ -46,7 +46,8 @@
 #'
 #' # Other projections
 #' nzmap + coord_map("cylindrical")
-#' nzmap + coord_map("azequalarea", orientation = c(-36.92,174.6,0))
+#' nzmap + coord_map("azequalarea", orientation = c(-36.92, 174.6, 0))
+#' nzmap + coord_map("lambert", parameters = c(-37, -44))
 #'
 #' states <- map_data("state")
 #' usamap <- ggplot(states, aes(long, lat, group = group)) +
@@ -83,12 +84,12 @@
 #' # Centered on New York (currently has issues with closing polygons)
 #' worldmap + coord_map("ortho", orientation = c(41, -74, 0))
 #' }
-coord_map <- function(projection="mercator", ..., orientation = NULL, xlim = NULL, ylim = NULL) {
+coord_map <- function(projection="mercator", parameters = NULL, orientation = NULL, xlim = NULL, ylim = NULL) {
   ggproto(NULL, CoordMap,
     projection = projection,
     orientation = orientation,
     limits = list(x = xlim, y = ylim),
-    params = list(...)
+    params = parameters
   )
 }
 

--- a/R/coord-map.r
+++ b/R/coord-map.r
@@ -21,7 +21,7 @@
 #' @export
 #' @param projection projection to use, see
 #'    \code{\link[mapproj]{mapproject}} for list
-#' @param ... other arguments passed on to mapproject
+#' @param ... other arguments passed on to mapproject. Ignored if the \code{parameters} argument is present.
 #' @param parameters optional numeric vector of parameters for use with the projection argument. This argument is optional only in the sense that certain projections do not require additional parameters. Passed to
 #'   \code{\link[mapproj]{mapproject}}
 #' @param orientation projection orientation, which defaults to

--- a/R/coord-map.r
+++ b/R/coord-map.r
@@ -21,6 +21,7 @@
 #' @export
 #' @param projection projection to use, see
 #'    \code{\link[mapproj]{mapproject}} for list
+#' @param ... other arguments passed on to mapproject
 #' @param parameters optional numeric vector of parameters for use with the projection argument. This argument is optional only in the sense that certain projections do not require additional parameters. Passed to
 #'   \code{\link[mapproj]{mapproject}}
 #' @param orientation projection orientation, which defaults to
@@ -84,12 +85,18 @@
 #' # Centered on New York (currently has issues with closing polygons)
 #' worldmap + coord_map("ortho", orientation = c(41, -74, 0))
 #' }
-coord_map <- function(projection="mercator", parameters = NULL, orientation = NULL, xlim = NULL, ylim = NULL) {
+coord_map <- function(projection="mercator", ..., parameters = NULL, orientation = NULL, xlim = NULL, ylim = NULL) {
+  if (is.null(parameters)) {
+    params <- list(...)
+  } else {
+    params <- parameters
+  }
+
   ggproto(NULL, CoordMap,
     projection = projection,
     orientation = orientation,
     limits = list(x = xlim, y = ylim),
-    params = parameters
+    params = params
   )
 }
 

--- a/man/coord_map.Rd
+++ b/man/coord_map.Rd
@@ -14,7 +14,7 @@ coord_quickmap(xlim = NULL, ylim = NULL, expand = TRUE)
 \item{projection}{projection to use, see
 \code{\link[mapproj]{mapproject}} for list}
 
-\item{...}{other arguments passed on to mapproject}
+\item{...}{other arguments passed on to mapproject. Ignored if the \code{parameters} argument is present.}
 
 \item{parameters}{optional numeric vector of parameters for use with the projection argument. This argument is optional only in the sense that certain projections do not require additional parameters. Passed to
 \code{\link[mapproj]{mapproject}}}

--- a/man/coord_map.Rd
+++ b/man/coord_map.Rd
@@ -14,10 +14,13 @@ coord_quickmap(xlim = NULL, ylim = NULL, expand = TRUE)
 \item{projection}{projection to use, see
 \code{\link[mapproj]{mapproject}} for list}
 
-\item{...}{other arguments passed on to mapproject. Ignored if the \code{parameters} argument is present.}
+\item{...}{other arguments passed on to \code{\link[mapproj]{mapproject}}.
+Ignored if the \code{parameters} argument is present.}
 
-\item{parameters}{optional numeric vector of parameters for use with the projection argument. This argument is optional only in the sense that certain projections do not require additional parameters. Passed to
-\code{\link[mapproj]{mapproject}}}
+\item{parameters}{optional numeric vector of parameters for use
+with the projection argument. This argument is optional only in
+the sense that certain projections do not require additional
+parameters. Passed to \code{\link[mapproj]{mapproject}}.}
 
 \item{orientation}{projection orientation, which defaults to
 \code{c(90, 0, mean(range(x)))}.  This is not optimal for many

--- a/man/coord_map.Rd
+++ b/man/coord_map.Rd
@@ -5,8 +5,8 @@
 \alias{coord_quickmap}
 \title{Map projections.}
 \usage{
-coord_map(projection = "mercator", ..., orientation = NULL, xlim = NULL,
-  ylim = NULL)
+coord_map(projection = "mercator", parameters = NULL, orientation = NULL,
+  xlim = NULL, ylim = NULL)
 
 coord_quickmap(xlim = NULL, ylim = NULL, expand = TRUE)
 }
@@ -14,7 +14,7 @@ coord_quickmap(xlim = NULL, ylim = NULL, expand = TRUE)
 \item{projection}{projection to use, see
 \code{\link[mapproj]{mapproject}} for list}
 
-\item{...}{other arguments passed on to
+\item{parameters}{optional numeric vector of parameters for use with the projection argument. This argument is optional only in the sense that certain projections do not require additional parameters. Passed to
 \code{\link[mapproj]{mapproject}}}
 
 \item{orientation}{projection orientation, which defaults to
@@ -65,7 +65,8 @@ nzmap + coord_quickmap()
 
 # Other projections
 nzmap + coord_map("cylindrical")
-nzmap + coord_map("azequalarea", orientation = c(-36.92,174.6,0))
+nzmap + coord_map("azequalarea", orientation = c(-36.92, 174.6, 0))
+nzmap + coord_map("lambert", parameters = c(-37, -44))
 
 states <- map_data("state")
 usamap <- ggplot(states, aes(long, lat, group = group)) +

--- a/man/coord_map.Rd
+++ b/man/coord_map.Rd
@@ -5,14 +5,16 @@
 \alias{coord_quickmap}
 \title{Map projections.}
 \usage{
-coord_map(projection = "mercator", parameters = NULL, orientation = NULL,
-  xlim = NULL, ylim = NULL)
+coord_map(projection = "mercator", ..., parameters = NULL,
+  orientation = NULL, xlim = NULL, ylim = NULL)
 
 coord_quickmap(xlim = NULL, ylim = NULL, expand = TRUE)
 }
 \arguments{
 \item{projection}{projection to use, see
 \code{\link[mapproj]{mapproject}} for list}
+
+\item{...}{other arguments passed on to mapproject}
 
 \item{parameters}{optional numeric vector of parameters for use with the projection argument. This argument is optional only in the sense that certain projections do not require additional parameters. Passed to
 \code{\link[mapproj]{mapproject}}}


### PR DESCRIPTION
I replaced the ... argument in coord_map() with parameters = NULL and added a new example in its help file for a projection that needs a 'parameters' argument. This fixes the bug mentioned in PR #1699.

In the previous version of coord_map(), the ... argument only served to pass the 'parameters' argument to mapproj::mapproject(), so it can be safely removed. I also added documentation about the new 'parameters' argument in coord_map().

P.S. I've now realized the proper workflow would have been to modify the original pull request at https://github.com/hadley/ggplot2/pull/1699 , but it's too late now.