### PR TITLE
Show a list of linetypes in scale_linetype docs

### DIFF
--- a/R/scale-linetype.r
+++ b/R/scale-linetype.r
@@ -14,6 +14,15 @@
 #' base + geom_line(aes(linetype = variable))
 #'
 #' # See scale_manual for more flexibility
+#'
+#' # show common line types
+#' df_lines <- data.frame(linetype = factor(1:4, labels = c("solid", "longdash", "dashed", "dotted")))
+#' ggplot(df_lines) +
+#'   geom_hline(aes(linetype = linetype, yintercept = 0), size = 2) +
+#'   scale_linetype_identity() +
+#'   facet_grid(linetype ~ .) +
+#'   theme_void(20)
+#'
 scale_linetype <- function(..., na.value = "blank") {
   discrete_scale("linetype", "linetype_d", linetype_pal(),
     na.value = na.value, ...)

--- a/man/scale_linetype.Rd
+++ b/man/scale_linetype.Rd
@@ -30,5 +30,14 @@ base + geom_line(aes(group = variable))
 base + geom_line(aes(linetype = variable))
 
 # See scale_manual for more flexibility
+
+# show common line types
+df_lines <- data.frame(linetype = factor(1:4, labels = c("solid", "longdash", "dashed", "dotted")))
+ggplot(df_lines) +
+  geom_hline(aes(linetype = linetype, yintercept = 0), size = 2) +
+  scale_linetype_identity() +
+  facet_grid(linetype ~ .) +
+  theme_void(20)
+
 }
 


### PR DESCRIPTION
Show a simple legend for common line types. It just saves people a trip to the vignette or online docs.

Similar to PR https://github.com/hadley/ggplot2/pull/1578