### PR TITLE
Pass dots to continuous_scale in scale_size/radius

### DIFF
--- a/R/scale-size.r
+++ b/R/scale-size.r
@@ -36,20 +36,20 @@ NULL
 #' @usage NULL
 scale_size_continuous <- function(name = waiver(), breaks = waiver(), labels = waiver(),
                                   limits = NULL, range = c(1, 6),
-                                  trans = "identity", guide = "legend") {
+                                  trans = "identity", guide = "legend", na.value=NA_real_) {
   continuous_scale("size", "area", area_pal(range), name = name,
     breaks = breaks, labels = labels, limits = limits, trans = trans,
-    guide = guide)
+    guide = guide, na.value=NA_real_)
 }
 
 #' @rdname scale_size
 #' @export
 scale_radius <- function(name = waiver(), breaks = waiver(), labels = waiver(),
                          limits = NULL, range = c(1, 6),
-                         trans = "identity", guide = "legend") {
+                         trans = "identity", guide = "legend", na.value=NA_real_) {
   continuous_scale("size", "radius", rescale_pal(range), name = name,
     breaks = breaks, labels = labels, limits = limits, trans = trans,
-    guide = guide)
+    guide = guide, na.value=NA_real_)
 }
 
 #' @rdname scale_size

--- a/man/scale_size.Rd
+++ b/man/scale_size.Rd
@@ -11,10 +11,12 @@
 \title{Scale size (area or radius).}
 \usage{
 scale_radius(name = waiver(), breaks = waiver(), labels = waiver(),
-  limits = NULL, range = c(1, 6), trans = "identity", guide = "legend")
+  limits = NULL, range = c(1, 6), trans = "identity", guide = "legend",
+  na.value = NA_real_)
 
 scale_size(name = waiver(), breaks = waiver(), labels = waiver(),
-  limits = NULL, range = c(1, 6), trans = "identity", guide = "legend")
+  limits = NULL, range = c(1, 6), trans = "identity", guide = "legend",
+  na.value = NA_real_)
 
 scale_size_area(..., max_size = 6)
 }
@@ -59,6 +61,8 @@ maximum size of the plotting symbol after transformation.}
   transformation with \code{\link[scales]{trans_new}}.}
 
 \item{guide}{Name of guide object, or object itself.}
+
+\item{na.value}{Missing values will be replaced with this value.}
 
 \item{...}{Other arguments passed on to \code{\link{continuous_scale}}
 to control name, limits, breaks, labels and so forth.}


### PR DESCRIPTION
I tried to pass `na.value` to `scale_size_continuous`, and was surprised when it threw an error instead of passing it along to `continuous_scale`.  This pull request fixes that by having it pass along `...`.