### PR TITLE
Scale gradient doc fix

### DIFF
--- a/R/scale-gradient.r
+++ b/R/scale-gradient.r
@@ -15,6 +15,8 @@
 #' @param low,high Colours for low and high ends of the gradient.
 #' @param guide Type of legend. Use \code{"colourbar"} for continuous
 #'   colour bar, or \code{"legend"} for discrete colour legend.
+#' @param ... Other arguments passed on to \code{\link{continuous_scale}}
+#'   to control name, limits, breaks, labels and so forth.
 #' @seealso \code{\link[scales]{seq_gradient_pal}} for details on underlying
 #'   palette
 #' @seealso Other colour scales:

--- a/man/scale_gradient.Rd
+++ b/man/scale_gradient.Rd
@@ -40,7 +40,7 @@ scale_fill_gradientn(..., colours, values = NULL, space = "Lab",
   na.value = "grey50", guide = "colourbar", colors)
 }
 \arguments{
-\item{...}{Other arguments passed on to \code{\link{discrete_scale}}
+\item{...}{Other arguments passed on to \code{\link{continuous_scale}}
 to control name, limits, breaks, labels and so forth.}
 
 \item{low, high}{Colours for low and high ends of the gradient.}


### PR DESCRIPTION
The documentation now mentions "continuous_scale" instead of "discrete_scale".

Fixes #1736.
