### PR TITLE
Pass super class to scale constructor

### DIFF
--- a/R/scale-.r
+++ b/R/scale-.r
@@ -531,13 +531,12 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
 #'   \code{c(0.05, 0)} for continuous variables, and \code{c(0, 0.6)} for
 #'   discrete variables.
 #' @param guide Name of guide object, or object itself.
+#' @param super The super class to use for the constructed scale
 #' @keywords internal
 continuous_scale <- function(aesthetics, scale_name, palette, name = waiver(),
-                             breaks = waiver(), minor_breaks = waiver(),
-                             labels = waiver(), limits = NULL,
-                             rescaler = rescale, oob = censor,
-                             expand = waiver(), na.value = NA_real_,
-                             trans = "identity", guide = "legend") {
+  breaks = waiver(), minor_breaks = waiver(), labels = waiver(), limits = NULL,
+  rescaler = rescale, oob = censor, expand = waiver(), na.value = NA_real_,
+  trans = "identity", guide = "legend", super = ScaleContinuous) {
 
   check_breaks_labels(breaks, labels)
 
@@ -550,7 +549,7 @@ continuous_scale <- function(aesthetics, scale_name, palette, name = waiver(),
     limits <- trans$transform(limits)
   }
 
-  ggproto(NULL, ScaleContinuous,
+  ggproto(NULL, super,
     call = match.call(),
 
     aesthetics = aesthetics,
@@ -614,10 +613,11 @@ continuous_scale <- function(aesthetics, scale_name, palette, name = waiver(),
 #' @param na.value how should missing values be displayed?
 #' @param guide the name of, or actual function, used to create the
 #'   guide. See \code{\link{guides}} for more info.
+#' @param super The super class to use for the constructed scale
 #' @keywords internal
-discrete_scale <- function(aesthetics, scale_name, palette, name = waiver(), breaks = waiver(),
-  labels = waiver(), limits = NULL, expand = waiver(), na.value = NA, drop = TRUE,
-  guide = "legend") {
+discrete_scale <- function(aesthetics, scale_name, palette, name = waiver(),
+  breaks = waiver(), labels = waiver(), limits = NULL, expand = waiver(),
+  na.value = NA, drop = TRUE, guide = "legend", super = ScaleDiscrete) {
 
   check_breaks_labels(breaks, labels)
 
@@ -625,7 +625,7 @@ discrete_scale <- function(aesthetics, scale_name, palette, name = waiver(), bre
     guide <- "none"
   }
 
-  ggproto(NULL, ScaleDiscrete,
+  ggproto(NULL, super,
     call = match.call(),
 
     aesthetics = aesthetics,

--- a/R/scale-continuous.r
+++ b/R/scale-continuous.r
@@ -86,13 +86,8 @@ scale_x_continuous <- function(name = waiver(), breaks = waiver(),
     "position_c", identity, name = name, breaks = breaks,
     minor_breaks = minor_breaks, labels = labels, limits = limits,
     expand = expand, oob = oob, na.value = na.value, trans = trans,
-    guide = "none"
+    guide = "none", super = ScaleContinuousPosition
   )
-
-  # TODO: Fix this hack. We're reassigning the parent ggproto object, but this
-  # object should in the first place be created with the correct parent.
-  sc$super <- ScaleContinuousPosition
-  class(sc) <- class(ScaleContinuousPosition)
 
   sc
 }
@@ -108,13 +103,8 @@ scale_y_continuous <- function(name = waiver(), breaks = waiver(),
     "position_c", identity, name = name, breaks = breaks,
     minor_breaks = minor_breaks, labels = labels, limits = limits,
     expand = expand, oob = oob, na.value = na.value, trans = trans,
-    guide = "none"
+    guide = "none", super = ScaleContinuousPosition
   )
-
-  # TODO: Fix this hack. We're reassigning the parent ggproto object, but this
-  # object should in the first place be created with the correct parent.
-  sc$super <- ScaleContinuousPosition
-  class(sc) <- class(ScaleContinuousPosition)
 
   sc
 }

--- a/R/scale-date.r
+++ b/R/scale-date.r
@@ -128,15 +128,11 @@ scale_datetime <- function(aesthetics, trans,
     labels <- date_format(date_labels)
   }
 
+  scale_class <- switch(trans, date = ScaleContinuousDate, time = ScaleContinuousDatetime)
   sc <- continuous_scale(aesthetics, name, identity,
     breaks = breaks, minor_breaks = minor_breaks, labels = labels,
-    guide = "none", trans = trans, ...)
+    guide = "none", trans = trans, ..., super = scale_class)
 
-  # TODO: Fix this hack. We're reassigning the parent ggproto object, but this
-  # object should in the first place be created with the correct parent.
-  scale_class <- switch(trans, date = ScaleContinuousDate, time = ScaleContinuousDatetime)
-  sc$super <- scale_class
-  class(sc) <- class(scale_class)
   sc
 }
 

--- a/R/scale-discrete-.r
+++ b/R/scale-discrete-.r
@@ -48,12 +48,7 @@
 #' }
 scale_x_discrete <- function(..., expand = waiver()) {
   sc <- discrete_scale(c("x", "xmin", "xmax", "xend"), "position_d", identity, ...,
-    expand = expand, guide = "none")
-
-  # TODO: Fix this hack. We're reassigning the parent ggproto object, but this
-  # object should in the first place be created with the correct parent.
-  sc$super <- ScaleDiscretePosition
-  class(sc) <- class(ScaleDiscretePosition)
+    expand = expand, guide = "none", super = ScaleDiscretePosition)
 
   sc$range_c <- continuous_range()
   sc
@@ -62,12 +57,7 @@ scale_x_discrete <- function(..., expand = waiver()) {
 #' @export
 scale_y_discrete <- function(..., expand = waiver()) {
   sc <- discrete_scale(c("y", "ymin", "ymax", "yend"), "position_d", identity, ...,
-    expand = expand, guide = "none")
-
-  # TODO: Fix this hack. We're reassigning the parent ggproto object, but this
-  # object should in the first place be created with the correct parent.
-  sc$super <- ScaleDiscretePosition
-  class(sc) <- class(ScaleDiscretePosition)
+    expand = expand, guide = "none", super = ScaleDiscretePosition)
 
   sc$range_c <- continuous_range()
   sc

--- a/R/scale-identity.r
+++ b/R/scale-identity.r
@@ -42,72 +42,54 @@ NULL
 #' @rdname scale_identity
 #' @export
 scale_colour_identity <- function(..., guide = "none") {
-  sc <- discrete_scale("colour", "identity", identity_pal(), ..., guide = guide)
+  sc <- discrete_scale("colour", "identity", identity_pal(), ..., guide = guide,
+    super = ScaleDiscreteIdentity)
 
-  # TODO: Fix this hack. We're reassigning the parent ggproto object, but this
-  # object should in the first place be created with the correct parent.
-  sc$super <- ScaleDiscreteIdentity
-  class(sc) <- class(ScaleDiscreteIdentity)
   sc
 }
 
 #' @rdname scale_identity
 #' @export
 scale_fill_identity <- function(..., guide = "none") {
-  sc <- discrete_scale("fill", "identity", identity_pal(), ..., guide = guide)
+  sc <- discrete_scale("fill", "identity", identity_pal(), ..., guide = guide,
+    super = ScaleDiscreteIdentity)
 
-  # TODO: Fix this hack. We're reassigning the parent ggproto object, but this
-  # object should in the first place be created with the correct parent.
-  sc$super <- ScaleDiscreteIdentity
-  class(sc) <- class(ScaleDiscreteIdentity)
   sc
 }
 
 #' @rdname scale_identity
 #' @export
 scale_shape_identity <- function(..., guide = "none") {
-  sc <- continuous_scale("shape", "identity", identity_pal(), ..., guide = guide)
+  sc <- continuous_scale("shape", "identity", identity_pal(), ..., guide = guide,
+    super = ScaleDiscreteIdentity)
 
-  # TODO: Fix this hack. We're reassigning the parent ggproto object, but this
-  # object should in the first place be created with the correct parent.
-  sc$super <- ScaleContinuousIdentity
-  class(sc) <- class(ScaleContinuousIdentity)
   sc
 }
 
 #' @rdname scale_identity
 #' @export
 scale_linetype_identity <- function(..., guide = "none") {
-  sc <- discrete_scale("linetype", "identity", identity_pal(), ..., guide = guide)
+  sc <- discrete_scale("linetype", "identity", identity_pal(), ..., guide = guide,
+    super = ScaleDiscreteIdentity)
 
-  # TODO: Fix this hack. We're reassigning the parent ggproto object, but this
-  # object should in the first place be created with the correct parent.
-  sc$super <- ScaleDiscreteIdentity
-  class(sc) <- class(ScaleDiscreteIdentity)
   sc
 }
 
 #' @rdname scale_identity
 #' @export
 scale_alpha_identity <- function(..., guide = "none") {
-  sc <- continuous_scale("alpha", "identity", identity_pal(), ..., guide = guide)
+  sc <- continuous_scale("alpha", "identity", identity_pal(), ..., guide = guide,
+    super = ScaleContinuousIdentity)
 
-  # TODO: Fix this hack. We're reassigning the parent ggproto object, but this
-  # object should in the first place be created with the correct parent.
-  sc$super <- ScaleContinuousIdentity
-  class(sc) <- class(ScaleContinuousIdentity)
   sc
 }
 
 #' @rdname scale_identity
 #' @export
 scale_size_identity <- function(..., guide = "none") {
-  sc <- continuous_scale("size", "identity", identity_pal(), ..., guide = guide)
+  sc <- continuous_scale("size", "identity", identity_pal(), ..., guide = guide,
+    super = ScaleContinuousIdentity)
 
-  # TODO: Fix this hack. We're reassigning the parent ggproto object, but this
-  # object should in the first place be created with the correct parent.
-  sc$super <- ScaleContinuousIdentity
-  class(sc) <- class(ScaleContinuousIdentity)
   sc
 }
 

--- a/man/continuous_scale.Rd
+++ b/man/continuous_scale.Rd
@@ -7,7 +7,8 @@
 continuous_scale(aesthetics, scale_name, palette, name = waiver(),
   breaks = waiver(), minor_breaks = waiver(), labels = waiver(),
   limits = NULL, rescaler = rescale, oob = censor, expand = waiver(),
-  na.value = NA_real_, trans = "identity", guide = "legend")
+  na.value = NA_real_, trans = "identity", guide = "legend",
+  super = ScaleContinuous)
 }
 \arguments{
 \item{aesthetics}{the names of the aesthetics that this scale works with}
@@ -78,6 +79,8 @@ discrete variables.}
   transformation with \code{\link[scales]{trans_new}}.}
 
 \item{guide}{Name of guide object, or object itself.}
+
+\item{super}{The super class to use for the constructed scale}
 }
 \description{
 Continuous scale constructor.

--- a/man/discrete_scale.Rd
+++ b/man/discrete_scale.Rd
@@ -6,7 +6,8 @@
 \usage{
 discrete_scale(aesthetics, scale_name, palette, name = waiver(),
   breaks = waiver(), labels = waiver(), limits = NULL,
-  expand = waiver(), na.value = NA, drop = TRUE, guide = "legend")
+  expand = waiver(), na.value = NA, drop = TRUE, guide = "legend",
+  super = ScaleDiscrete)
 }
 \arguments{
 \item{aesthetics}{the names of the aesthetics that this scale works with}
@@ -55,6 +56,8 @@ The default, \code{TRUE}, uses the levels that appear in the data;
 
 \item{guide}{the name of, or actual function, used to create the
 guide. See \code{\link{guides}} for more info.}
+
+\item{super}{The super class to use for the constructed scale}
 }
 \description{
 Discrete scale constructor.


### PR DESCRIPTION
Fixes #1732.

`continuous_scale` and `discrete_scale` now takes a `super` argument that defaults to `ScaleContinuous` and `ScaleDiscrete` respectively. This avoids having to reassign the super class after construction in the different positional scale constructors