### PR TITLE
Approach facet_grid(scale="free") + coord_flip issue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 2.1.0.9000 
 
+* Fixed facet_grid(scale="free") + coord_flip() behavior (@vlsi, #1492, #1470, #1393, #95)
+
 * The documentation for theme elements has been improved (#1743).
 
 * `geom_boxplot` gain new `outlier.alpha` argument for controlling the alpha of

--- a/R/facet-wrap.r
+++ b/R/facet-wrap.r
@@ -144,9 +144,9 @@ facet_render.wrap <- function(facet, panel, coord, theme, geom_grobs) {
 
   # If coord is (non-cartesian or flip) and (x is free or y is free)
   # then print a warning
-  if ((!inherits(coord, "CoordCartesian") || inherits(coord, "CoordFlip")) &&
+  if (!inherits(coord, "CoordCartesian") &&
     (facet$free$x || facet$free$y)) {
-    stop("ggplot2 does not currently support free scales with a non-cartesian coord or coord_flip.\n")
+    stop("ggplot2 does not currently support free scales with a non-cartesian coord.\n")
   }
 
   # If user hasn't set aspect ratio, and we have fixed scales, then

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -39,6 +39,15 @@ ggplot_build <- function(plot) {
 
   panel <- new_panel()
   panel <- train_layout(panel, plot$facet, layer_data, plot$data)
+
+  # If coordinates will be flipped, then flip panels to train coordinates from
+  if (inherits(plot$coordinates, "CoordFlip")) {
+    # This fixes facet_grid(scale="free") + coord_flip() issue
+    tmp <- panel$layout$SCALE_X
+    panel$layout$SCALE_X <- panel$layout$SCALE_Y
+    panel$layout$SCALE_Y <- tmp
+  }
+
   data <- map_layout(panel, plot$facet, layer_data)
 
   # Compute aesthetics to produce data with generalised variable names

--- a/tests/testthat/test-facet-.r
+++ b/tests/testthat/test-facet-.r
@@ -36,6 +36,25 @@ test_that("facets with free scales scale independently", {
   expect_true(sd(d3$y) < 1e-10)
 })
 
+test_that("facets with free scales scale independently in case of coord_flip", {
+  l1 <- ggplot(df, aes(x, y)) + geom_point() + coord_flip() +
+    facet_wrap(~z, scales = "free")
+  d1 <- cdata(l1)[[1]]
+  expect_true(sd(d1$x) < 1e-10)
+  expect_true(sd(d1$y) < 1e-10)
+
+  l2 <- ggplot(df, aes(x, y)) + geom_point() + coord_flip() +
+    facet_grid(. ~ z, scales = "free")
+  d2 <- cdata(l2)[[1]]
+  expect_true(sd(d2$x) < 1e-10)
+  expect_equal(length(unique(d2$y)), 3)
+
+  l3 <- ggplot(df, aes(x, y)) + geom_point() + coord_flip() +
+    facet_grid(z ~ ., scales = "free")
+  d3 <- cdata(l3)[[1]]
+  expect_equal(length(unique(d3$x)), 3)
+  expect_true(sd(d3$y) < 1e-10)
+})
 
 test_that("shrink parameter affects scaling", {
   l1 <- ggplot(df, aes(1, y)) + geom_point()


### PR DESCRIPTION
I've run into "well known" `facet_grid(scale="free") + coord_flip()` issue, and it took me a several hours to find a workaround, thus I decided to implement a proper fix.

The idea is to swap panel$layout$SCALE_X and panel$layout$SCALE_Y right after train_layout

The thing is facet_grid tries to keep the same ranges for all columns and rows,
however it does not know if the axes will be flipped, so when flip occurs
the previously chosen set of facets no longer applies.

The fix is to flip SCALE_X and SCALE_Y set of facets, so the ranges are properly computed

Fixes #1492, #1470, #1393, #95