### PR TITLE
show.legend can now be a logical vector

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,8 @@
   degrees Fahrenheit). The secondary axis will be positioned opposite of the 
   primary axis and can be controlled using the `sec.axis` argument to the scale
   constructor.
+  
+* Aesthetics can now independently hidden in the legend (@Tutuchan).
 
 * The documentation for theme elements has been improved (#1743).
 

--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -132,6 +132,13 @@
 #'
 #' # reversed order legend
 #' p + guides(col = guide_legend(reverse = TRUE))
+#'
+#' # hide some aesthetics from the legend
+#' p4 <- ggplot(mtcars, aes(mpg, qsec, colour = factor(vs), shape = factor(am))) +
+#'   geom_point()
+#' p4 + geom_line()
+#' p4 + geom_line(show.legend = c(colour = FALSE))
+#'
 #' }
 guide_legend <- function(
 
@@ -260,8 +267,12 @@ guide_geom.legend <- function(guide, layers, default_mapping) {
 
     if (length(matched) > 0) {
       # This layer contributes to the legend
-      if (is.na(layer$show.legend) || layer$show.legend) {
-        # Default is to include it
+      show_legend <- layer$show.legend[matched]
+      show_legend <- if (!has_name(show_legend)) {
+        # There is no specific rule for this aesthetic, check if there is a global rule (i.e. show.legend is a scalar)
+        if (!has_name(layer$show.legend)) layer$show.legend || is.na(layer$show.legend) else TRUE
+        } else unname(show_legend)
+      if (show_legend) {
         data <- layer$geom$use_defaults(guide$key[matched], layer$aes_params)
       } else {
         return(NULL)

--- a/R/layer.r
+++ b/R/layer.r
@@ -31,6 +31,7 @@
 #' @param show.legend logical. Should this layer be included in the legends?
 #'   \code{NA}, the default, includes if any aesthetics are mapped.
 #'   \code{FALSE} never includes, and \code{TRUE} always includes.
+#'   Can also be a named logical vector to specify which aesthetics to include.
 #' @param inherit.aes If \code{FALSE}, overrides the default aesthetics,
 #'   rather than combining with them. This is most useful for helper functions
 #'   that define both data and aesthetics and shouldn't inherit behaviour from

--- a/R/layer.r
+++ b/R/layer.r
@@ -72,8 +72,8 @@ layer <- function(geom = NULL, stat = NULL,
     show.legend <- params$show_guide
     params$show_guide <- NULL
   }
-  if (!is.logical(show.legend) || length(show.legend) != 1) {
-    warning("`show.legend` must be a logical vector of length 1.", call. = FALSE)
+  if (!is.logical(show.legend)) {
+    warning("`show.legend` must be a logical vector.", call. = FALSE)
     show.legend <- FALSE
   }
 

--- a/man/geom_abline.Rd
+++ b/man/geom_abline.Rd
@@ -45,7 +45,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{xintercept, yintercept, slope, intercept}{Parameters that control the
 position of the line. If these are set, \code{data}, \code{mapping} and

--- a/man/geom_bar.Rd
+++ b/man/geom_bar.Rd
@@ -52,7 +52,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_bin2d.Rd
+++ b/man/geom_bin2d.Rd
@@ -47,7 +47,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_blank.Rd
+++ b/man/geom_blank.Rd
@@ -40,7 +40,8 @@ to the paired geom/stat.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_boxplot.Rd
+++ b/man/geom_boxplot.Rd
@@ -67,7 +67,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_col.Rd
+++ b/man/geom_col.Rd
@@ -42,7 +42,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_contour.Rd
+++ b/man/geom_contour.Rd
@@ -55,7 +55,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_count.Rd
+++ b/man/geom_count.Rd
@@ -46,7 +46,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_density.Rd
+++ b/man/geom_density.Rd
@@ -46,7 +46,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_density_2d.Rd
+++ b/man/geom_density_2d.Rd
@@ -54,7 +54,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_dotplot.Rd
+++ b/man/geom_dotplot.Rd
@@ -80,7 +80,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_errorbarh.Rd
+++ b/man/geom_errorbarh.Rd
@@ -44,7 +44,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_hex.Rd
+++ b/man/geom_hex.Rd
@@ -47,7 +47,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_histogram.Rd
+++ b/man/geom_histogram.Rd
@@ -52,7 +52,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_jitter.Rd
+++ b/man/geom_jitter.Rd
@@ -62,7 +62,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_linerange.Rd
+++ b/man/geom_linerange.Rd
@@ -63,7 +63,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_map.Rd
+++ b/man/geom_map.Rd
@@ -45,7 +45,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_path.Rd
+++ b/man/geom_path.Rd
@@ -63,7 +63,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_point.Rd
+++ b/man/geom_point.Rd
@@ -44,7 +44,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_polygon.Rd
+++ b/man/geom_polygon.Rd
@@ -44,7 +44,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_quantile.Rd
+++ b/man/geom_quantile.Rd
@@ -53,7 +53,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_ribbon.Rd
+++ b/man/geom_ribbon.Rd
@@ -49,7 +49,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_rug.Rd
+++ b/man/geom_rug.Rd
@@ -48,7 +48,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_segment.Rd
+++ b/man/geom_segment.Rd
@@ -54,7 +54,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -64,7 +64,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_spoke.Rd
+++ b/man/geom_spoke.Rd
@@ -45,7 +45,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_text.Rd
+++ b/man/geom_text.Rd
@@ -64,7 +64,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_tile.Rd
+++ b/man/geom_tile.Rd
@@ -62,7 +62,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/geom_violin.Rd
+++ b/man/geom_violin.Rd
@@ -57,7 +57,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/guide_legend.Rd
+++ b/man/guide_legend.Rd
@@ -168,6 +168,13 @@ p + guides(col = guide_legend(ncol = 8, byrow = TRUE))
 
 # reversed order legend
 p + guides(col = guide_legend(reverse = TRUE))
+
+# hide some aesthetics from the legend
+p4 <- ggplot(mtcars, aes(mpg, qsec, colour = factor(vs), shape = factor(am))) +
+  geom_point()
+p4 + geom_line()
+p4 + geom_line(show.legend = c(colour = FALSE))
+
 }
 }
 \seealso{

--- a/man/layer.Rd
+++ b/man/layer.Rd
@@ -48,7 +48,8 @@ layer.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 }
 \description{
 A layer is a combination of data, stat and geom with a potential position

--- a/man/stat_ecdf.Rd
+++ b/man/stat_ecdf.Rd
@@ -49,7 +49,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/stat_ellipse.Rd
+++ b/man/stat_ellipse.Rd
@@ -55,7 +55,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/stat_function.Rd
+++ b/man/stat_function.Rd
@@ -51,7 +51,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/stat_identity.Rd
+++ b/man/stat_identity.Rd
@@ -39,7 +39,8 @@ to the paired geom/stat.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/stat_qq.Rd
+++ b/man/stat_qq.Rd
@@ -53,7 +53,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/stat_summary.Rd
+++ b/man/stat_summary.Rd
@@ -60,7 +60,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/stat_summary_2d.Rd
+++ b/man/stat_summary_2d.Rd
@@ -63,7 +63,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions

--- a/man/stat_unique.Rd
+++ b/man/stat_unique.Rd
@@ -43,7 +43,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+Can also be a named logical vector to specify which aesthetics to include.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions


### PR DESCRIPTION
Hi,

With this PR, it is now possible to pass a named logical vector to `show.legend` in order to have better control of what appears in the legend or not. See this example: 

```r
library(ggplot2)

p <- ggplot(mtcars) +
  geom_point(aes(mpg, qsec, colour = factor(vs), shape = factor(am)))

p + geom_line(aes(mpg, qsec, colour = factor(vs), linetype = factor(am)))

# Current behaviour: remove this layer from the legend
p + geom_line(aes(mpg, qsec, colour = factor(vs), linetype = factor(am)), show.legend = FALSE)

# In the current version, this would have the same behaviour but here, 
# it removes only the colour aesthetic for the line geom from the legend
p + geom_line(aes(mpg, qsec, colour = factor(vs), linetype = factor(am)), 
              show.legend = c(colour = FALSE))
```

![image](https://cloud.githubusercontent.com/assets/5540005/18636453/2c7300ca-7e89-11e6-8398-ae3378826ccb.png)

The only problem (that I see anyway) is that, for the colour scale, the name in the `show.legend` vector **must** be `colour`, `color` will not work. It might be solved by adding a check when trying to match the names but it's not very elegant. Any ideas ?