### PR TITLE
Fix jitter width and jitter height

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -175,6 +175,9 @@
     * Added `legend.box.spacing` to control the distance between the plot area 
       and the legend area
 
+* Fixed the jitter width and jitter height of `position_jitter` when the
+  parameters are supplied by the user. (#1775, @has2k1)
+
 # ggplot2 2.1.0
 
 ## New features

--- a/R/position-jitter.r
+++ b/R/position-jitter.r
@@ -44,8 +44,8 @@ PositionJitter <- ggproto("PositionJitter", Position,
 
   setup_params = function(self, data) {
     list(
-      width = self$width %||% resolution(data$x, zero = FALSE) * 0.4,
-      height = self$height %||% resolution(data$y, zero = FALSE) * 0.4
+      width = self$width %||% (resolution(data$x, zero = FALSE) * 0.4),
+      height = self$height %||% (resolution(data$y, zero = FALSE) * 0.4)
     )
   },
 

--- a/R/position-jitterdodge.R
+++ b/R/position-jitterdodge.R
@@ -38,7 +38,7 @@ PositionJitterdodge <- ggproto("PositionJitterdodge", Position,
   required_aes = c("x", "y"),
 
   setup_params = function(self, data) {
-    width <- self$jitter.width %||% resolution(data$x, zero = FALSE) * 0.4
+    width <- self$jitter.width %||% (resolution(data$x, zero = FALSE) * 0.4)
     # Adjust the x transformation based on the number of 'dodge' variables
     dodgecols <- intersect(c("fill", "colour", "linetype", "shape", "size", "alpha"), colnames(data))  
     if (length(dodgecols) == 0) {

--- a/R/stat-boxplot.r
+++ b/R/stat-boxplot.r
@@ -46,7 +46,7 @@ StatBoxplot <- ggproto("StatBoxplot", Stat,
   non_missing_aes = "weight",
 
   setup_params = function(data, params) {
-    params$width <- params$width %||% resolution(data$x) * 0.75
+    params$width <- params$width %||% (resolution(data$x) * 0.75)
 
     if (is.double(data$x) && !has_groups(data) && any(data$x != data$x[1L])) {
       warning(


### PR DESCRIPTION
The problem was the %||% operator accepts single tokens and so
care (bracketing as required) must be taken avoid miscalculations.

Some other places in the code-base had it right.

Fixes #1775