### PR TITLE
link to geom_count from geom_point help

### DIFF
--- a/R/geom-point.r
+++ b/R/geom-point.r
@@ -28,7 +28,9 @@
 #'
 #' @seealso \code{\link{scale_size}} to see scale area of points, instead of
 #'   radius, \code{\link{geom_jitter}} to jitter points to reduce (mild)
-#'   overplotting
+#'   overplotting, \code{\link{geom_count}} to count the number of points 
+#'   at unique locations on a scatterplot and map the size of the point to
+#'   the count.
 #' @inheritParams layer
 #' @param na.rm If \code{FALSE} (the default), removes missing values with
 #'    a warning.  If \code{TRUE} silently removes missing values.


### PR DESCRIPTION
It could be useful to link `geom_count()` from the `geom_point()` help, since this geom provides a nice solution to overplotting but is not easy to find.