### PR TITLE
coord_map: print x-axis ticks on bottom

### DIFF
--- a/R/coord-map.r
+++ b/R/coord-map.r
@@ -242,8 +242,8 @@ CoordMap <- ggproto("CoordMap", Coord,
     pos <- self$transform(x_intercept, scale_details)
 
     axes <- list(
-      top = guide_axis(pos$x, scale_details$x.labels, "top", theme),
-      bottom = guide_axis(pos$x, scale_details$x.labels, "bottom", theme)
+      bottom = guide_axis(pos$x, scale_details$x.labels, "bottom", theme),
+      top = guide_axis(pos$x, scale_details$x.labels, "top", theme)
     )
     axes[[which(arrange == "secondary")]] <- zeroGrob()
     axes


### PR DESCRIPTION
Fixes a bug in `CoordMap` that makes the x-axis ticks (but not title) appear on top of the graphic.

```{r}
df <- expand.grid(
  lon = seq(-95.8, -94.9, .1),
  lat = seq(29.4, 30.1, .1)
)

ggplot(df, aes(lon, lat)) +
  geom_point()
```
<img width="508" alt="coord-map-1" src="https://cloud.githubusercontent.com/assets/424139/19525902/20720994-95e8-11e6-9a66-95a13696e4f8.png">
```{r}
# axis title and ticks on top, fine
ggplot(df, aes(lon, lat)) +
  geom_point() +
  scale_x_continuous(position = "top")
```
<img width="506" alt="coord-map-2" src="https://cloud.githubusercontent.com/assets/424139/19525937/4998e9e6-95e8-11e6-9676-c0a5aba56683.png">
```{r}
# axis title on bottom, ticks on top
ggplot(df, aes(lon, lat)) +
  geom_point() +
  coord_map()
```
<img width="504" alt="coord-map-3" src="https://cloud.githubusercontent.com/assets/424139/19525964/67001be4-95e8-11e6-8d27-93d13c2ab8a0.png">
This commit (a minor two line swap) puts the ticks back on the bottom.